### PR TITLE
Title: Fix persistence of blocked images

### DIFF
--- a/pkg/wallpaper/wallpaper.go
+++ b/pkg/wallpaper/wallpaper.go
@@ -233,6 +233,9 @@ func (wp *Plugin) DeleteCurrentImage() {
 
 	idToDelete := wp.currentImage.ID
 
+	// Persist to AvoidSet (Config)
+	wp.cfg.AddToAvoidSet(idToDelete)
+
 	// Send delete command to State Manager
 	if wp.pipeline != nil {
 		wp.pipeline.SendCommand(StateCmd{Type: CmdRemove, Payload: idToDelete})


### PR DESCRIPTION
## Problem
When using the "Delete and Block" feature, the image was removed from the current session's memory store but the block was not being persisted to the `config.json` file. This caused blocked images to be eligible for download again after an application restart.

## Solution
Updated [DeleteCurrentImage](cci:1://file:///c:/Users/karlk/development/Go/src/github.com/dixieflatline76/Spice/pkg/wallpaper/wallpaper.go:227:0-256:1) in [pkg/wallpaper/wallpaper.go](cci:7://file:///c:/Users/karlk/development/Go/src/github.com/dixieflatline76/Spice/pkg/wallpaper/wallpaper.go:0:0-0:0) to explicitly call `wp.cfg.AddToAvoidSet(id)`. This ensures that every block action is immediately saved to the permanent configuration.