### PR TITLE
fix: Repair Safari Extension build process and resolve WebSocket crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,8 @@ jobs:
           cp -R "build/Build/Products/Release/Spice Wallpaper Manager Extension.app" .
 
           # Now build the main app
-          make build-darwin-arm64
+          # We set SKIP_EXTENSION_BUILD=1 because we just built and signed it above
+          SKIP_EXTENSION_BUILD=1 make build-darwin-arm64
         
       - name: Notarize macOS App
         run: make notarize-mac-arm64

--- a/Spice Wallpaper Manager Extension/macOS (Extension)/Info.plist
+++ b/Spice Wallpaper Manager Extension/macOS (Extension)/Info.plist
@@ -9,5 +9,10 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
 	</dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/Spice Wallpaper Manager Extension/macOS (Extension)/Spice Wallpaper Manager Extension.entitlements
+++ b/Spice Wallpaper Manager Extension/macOS (Extension)/Spice Wallpaper Manager Extension.entitlements
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,6 +10,8 @@
   ],
   "host_permissions": [
     "http://127.0.0.1:49452/*",
+    "ws://127.0.0.1:49452/*",
+    "ws://localhost:49452/*",
     "https://wallhaven.cc/*",
     "https://*.wikimedia.org/*",
     "https://www.pexels.com/*",


### PR DESCRIPTION
## Summary
Resolves critical issues where the Safari Web Extension was shipping with stale code and crashing immediately upon connection due to Endpoint Security interference.
## Key Changes
### 1. Build System
- **Makefile**: Added `build-extension` target to compile source before packaging.
- **CI**: Updated workflow to coexist with local build logic.
### 2. Signing & Entitlements
- **Entitlements**: Added `network.client` to Extension Appex.
- **Info.plist**: Added `NSAllowsLocalNetworking` to bypass ATS blocks.
### 3. Stability
- **Manifest**: Added explicit `ws://` permissions for Safari.
- **Resilience**: Wrapped WebSocket creation in `try/catch` to preventing crashing when EDR (e.g., HarfangLab) blocks the connection.