### PR TITLE
fix: resolve query list scroll recycling and post-apply logic flip bugs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/fyne-io/image v0.1.1 // indirect
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20250301202403-da16c1255728 // indirect
-	github.com/go-text/render v0.2.0 // indirect
+	github.com/go-text/render v0.2.1 // indirect
 	github.com/go-text/typesetting v0.3.4 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 h1:5BVwOaUSBTlVZowGO6VZGw
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20250301202403-da16c1255728 h1:RkGhqHxEVAvPM0/R+8g7XRwQnHatO0KAuVcwHo8q9W8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20250301202403-da16c1255728/go.mod h1:SyRD8YfuKk+ZXlDqYiqe1qMSqjNgtHzBTG810KUagMc=
-github.com/go-text/render v0.2.0 h1:LBYoTmp5jYiJ4NPqDc2pz17MLmA3wHw1dZSVGcOdeAc=
-github.com/go-text/render v0.2.0/go.mod h1:CkiqfukRGKJA5vZZISkjSYrcdtgKQWRa2HIzvwNN5SU=
+github.com/go-text/render v0.2.1 h1:qwHhxqGUjjg4L0XyJWj7M7bpY75NZM+kBpv2Yfw5mcg=
+github.com/go-text/render v0.2.1/go.mod h1:HCCAq8MUlm/WRcXshBb4K/n+IkjeXQ1c2Ba+yICSm0A=
 github.com/go-text/typesetting v0.3.4 h1:YYurUOtEb9kGSOz4uE3k4OpBGsp1dDL8+fjCeaFamAU=
 github.com/go-text/typesetting v0.3.4/go.mod h1:4qZCQphq4KSgGTAeI0uMEkVbROgfah8BuyF5LRYr7XY=
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=

--- a/pkg/ui/setting/setting_manager.go
+++ b/pkg/ui/setting/setting_manager.go
@@ -106,6 +106,8 @@ type SettingsManager interface {
 	GetValue(name string) interface{}
 	// SetValue programmatically updates the live value of a setting.
 	SetValue(name string, val interface{})
+	// HasPendingChange returns true if the user has toggled a setting but not yet applied.
+	HasPendingChange(name string) bool
 	// Refresh triggers all registered refresh functions immediately.
 	Refresh()
 }

--- a/pkg/wallpaper/providers/googlephotos/provider.go
+++ b/pkg/wallpaper/providers/googlephotos/provider.go
@@ -560,118 +560,25 @@ func (p *Provider) cleanupDownload(guid string) {
 }
 
 func (p *Provider) createImgQueryList(sm setting.SettingsManager) *widget.List {
-	var queryList *widget.List
-	queryList = widget.NewList(
-		func() int {
-			return len(p.cfg.GetGooglePhotosQueries())
-		},
-		p.createCollectionItem,
-		func(i int, o fyne.CanvasObject) {
+	return wallpaper.CreateQueryList(sm, wallpaper.QueryListConfig{
+		GetQueries:   p.cfg.GetGooglePhotosQueries,
+		EnableQuery:  p.cfg.EnableGooglePhotosQuery,
+		DisableQuery: p.cfg.DisableGooglePhotosQuery,
+		RemoveQuery: func(id string) error {
+			// Google Photos needs file cleanup before removing the query
 			queries := p.cfg.GetGooglePhotosQueries()
-			if i >= len(queries) {
-				return
+			for _, q := range queries {
+				if q.ID == id {
+					u, _ := url.Parse(q.URL)
+					if u != nil && u.Host != "" {
+						p.cleanupDownload(u.Host)
+					}
+					break
+				}
 			}
-			p.updateCollectionItem(sm, queries[i], o, queryList)
+			return p.cfg.RemoveGooglePhotosQuery(id)
 		},
-	)
-	return queryList
-}
-
-func (p *Provider) createCollectionItem() fyne.CanvasObject {
-	label := widget.NewLabel("Collection Description")
-	label.Truncation = fyne.TextTruncateEllipsis
-
-	activeCheck := widget.NewCheck("", nil)
-	delBtn := widget.NewButton("Delete", nil)
-
-	rightGroup := container.NewHBox(widget.NewLabel("Active"), activeCheck, delBtn)
-	return container.NewBorder(nil, nil, nil, rightGroup, label)
-}
-
-func (p *Provider) updateCollectionItem(sm setting.SettingsManager, q wallpaper.ImageQuery, o fyne.CanvasObject, list *widget.List) {
-	label, activeCheck, delBtn := p.unpackCollectionUI(o)
-
-	if label != nil {
-		label.SetText(q.Description)
-	}
-
-	if activeCheck != nil && delBtn != nil {
-		activeCheck.OnChanged = nil
-		sm.SeedBaseline(q.ID, q.Active)
-		activeCheck.SetChecked(q.Active)
-
-		activeCheck.OnChanged = func(b bool) {
-			p.handleQueryActivation(sm, q, b)
-		}
-
-		delBtn.OnTapped = func() {
-			p.handleQueryDeletion(sm, q, list)
-		}
-	}
-}
-
-func (p *Provider) unpackCollectionUI(o fyne.CanvasObject) (*widget.Label, *widget.Check, *widget.Button) {
-	var label *widget.Label
-	var activeCheck *widget.Check
-	var delBtn *widget.Button
-
-	c := o.(*fyne.Container)
-	for _, obj := range c.Objects {
-		if l, ok := obj.(*widget.Label); ok {
-			label = l
-		}
-		if con, ok := obj.(*fyne.Container); ok {
-			for _, subObj := range con.Objects {
-				if chk, ok := subObj.(*widget.Check); ok {
-					activeCheck = chk
-				}
-				if btn, ok := subObj.(*widget.Button); ok {
-					delBtn = btn
-				}
-			}
-		}
-	}
-	return label, activeCheck, delBtn
-}
-
-func (p *Provider) handleQueryActivation(sm setting.SettingsManager, q wallpaper.ImageQuery, active bool) {
-	if active != sm.GetBaseline(q.ID).(bool) {
-		sm.SetSettingChangedCallback(q.ID, func() {
-			var err error
-			if active {
-				err = p.cfg.EnableGooglePhotosQuery(q.ID)
-			} else {
-				err = p.cfg.DisableGooglePhotosQuery(q.ID)
-			}
-			if err != nil {
-				log.Printf("Failed to update query status: %v", err)
-			}
-		})
-		sm.SetRefreshFlag(q.ID)
-	} else {
-		sm.RemoveSettingChangedCallback(q.ID)
-		sm.UnsetRefreshFlag(q.ID)
-	}
-	sm.GetCheckAndEnableApplyFunc()()
-}
-
-func (p *Provider) handleQueryDeletion(sm setting.SettingsManager, q wallpaper.ImageQuery, list *widget.List) {
-	dialog.ShowConfirm("Delete Collection", "Delete this collection and all local files?", func(b bool) {
-		if !b {
-			return
-		}
-		u, _ := url.Parse(q.URL)
-		if u != nil && u.Host != "" {
-			p.cleanupDownload(u.Host)
-		}
-
-		if err := p.cfg.RemoveGooglePhotosQuery(q.ID); err != nil {
-			dialog.ShowError(err, sm.GetSettingsWindow())
-			return
-		}
-		sm.SetRefreshFlag("queries")
-		list.Refresh()
-	}, sm.GetSettingsWindow())
+	})
 }
 
 func (p *Provider) migrateOldGooglePhotos() {

--- a/pkg/wallpaper/providers/pexels/pexels.go
+++ b/pkg/wallpaper/providers/pexels/pexels.go
@@ -19,7 +19,6 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/validation"
 	"fyne.io/fyne/v2/dialog"
-	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 	"github.com/dixieflatline76/Spice/v2/pkg/provider"
 	"github.com/dixieflatline76/Spice/v2/pkg/ui/setting"
@@ -594,85 +593,12 @@ func (p *PexelsProvider) CreateQueryPanel(sm setting.SettingsManager, pendingUrl
 }
 
 func (p *PexelsProvider) createImgQueryList(sm setting.SettingsManager) *widget.List {
-	var queryList *widget.List
-	queryList = widget.NewList(
-		func() int {
-			return len(p.cfg.GetPexelsQueries())
-		},
-		func() fyne.CanvasObject {
-			urlLink := widget.NewHyperlink("Placeholder", nil)
-			activeCheck := widget.NewCheck("Active", nil)
-			deleteButton := widget.NewButton("Delete", nil)
-
-			return container.NewHBox(urlLink, layout.NewSpacer(), activeCheck, deleteButton)
-		},
-		func(i int, o fyne.CanvasObject) {
-			queries := p.cfg.GetPexelsQueries()
-			if i >= len(queries) {
-				return
-			}
-			query := queries[i]
-			queryKey := query.ID
-
-			c := o.(*fyne.Container)
-
-			urlLink := c.Objects[0].(*widget.Hyperlink)
-			urlLink.SetText(query.Description)
-
-			if u, err := url.Parse(query.URL); err == nil {
-				urlLink.SetURL(u)
-			} else {
-				if err := urlLink.SetURLFromString(query.URL); err != nil {
-					log.Printf("Failed to set URL from string: %v", err)
-				}
-			}
-
-			activeCheck := c.Objects[2].(*widget.Check)
-			deleteButton := c.Objects[3].(*widget.Button)
-
-			sm.SeedBaseline(queryKey, query.Active)
-			activeCheck.SetChecked(query.Active)
-
-			activeCheck.OnChanged = func(b bool) {
-				if b != sm.GetBaseline(queryKey).(bool) {
-					sm.SetSettingChangedCallback(queryKey, func() {
-						var err error
-						if b {
-							err = p.cfg.EnablePexelsQuery(query.ID)
-						} else {
-							err = p.cfg.DisablePexelsQuery(query.ID)
-						}
-						if err != nil {
-							log.Printf("Failed to update query status: %v", err)
-						}
-					})
-					sm.SetRefreshFlag(queryKey)
-				} else {
-					sm.RemoveSettingChangedCallback(queryKey)
-					sm.UnsetRefreshFlag(queryKey)
-				}
-				sm.GetCheckAndEnableApplyFunc()()
-			}
-
-			deleteButton.OnTapped = func() {
-				d := dialog.NewConfirm("Please Confirm", fmt.Sprintf("Are you sure you want to delete %s?", query.Description), func(b bool) {
-					if b {
-						if query.Active {
-							sm.SetRefreshFlag(queryKey)
-							sm.GetCheckAndEnableApplyFunc()()
-						}
-						if err := p.cfg.RemovePexelsQuery(query.ID); err != nil {
-							log.Printf("Failed to remove Pexels query: %v", err)
-						}
-						queryList.Refresh()
-					}
-
-				}, sm.GetSettingsWindow())
-				d.Show()
-			}
-		},
-	)
-	return queryList
+	return wallpaper.CreateQueryList(sm, wallpaper.QueryListConfig{
+		GetQueries:   p.cfg.GetPexelsQueries,
+		EnableQuery:  p.cfg.EnablePexelsQuery,
+		DisableQuery: p.cfg.DisablePexelsQuery,
+		RemoveQuery:  p.cfg.RemovePexelsQuery,
+	})
 }
 
 // GetProviderIcon returns the provider's icon for the tray menu.

--- a/pkg/wallpaper/providers/wallhaven/wallhaven.go
+++ b/pkg/wallpaper/providers/wallhaven/wallhaven.go
@@ -17,7 +17,6 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/data/validation"
 	"fyne.io/fyne/v2/dialog"
-	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 	"github.com/dixieflatline76/Spice/v2/pkg/provider"
 	"github.com/dixieflatline76/Spice/v2/pkg/ui/setting"
@@ -781,95 +780,13 @@ func (p *WallhavenProvider) CreateQueryPanel(sm setting.SettingsManager, pending
 }
 
 func (p *WallhavenProvider) createImgQueryList(sm setting.SettingsManager) *widget.List {
-	var queryList *widget.List
-	queryList = widget.NewList(
-		func() int {
-			return len(p.cfg.GetImageQueries())
-		},
-		func() fyne.CanvasObject {
-			urlLink := widget.NewHyperlink("Placeholder", nil)
-			activeCheck := widget.NewCheck("Active", nil)
-			deleteButton := widget.NewButton("Delete", nil)
-
-			return container.NewHBox(urlLink, layout.NewSpacer(), activeCheck, deleteButton)
-		},
-		func(i int, o fyne.CanvasObject) {
-			queries := p.cfg.GetImageQueries()
-			if i >= len(queries) {
-				return
-			}
-			query := queries[i]
-			queryKey := query.ID
-
-			c := o.(*fyne.Container)
-
-			urlLink := c.Objects[0].(*widget.Hyperlink)
-			urlLink.SetText(query.Description)
-
-			siteURL := p.getWebURL(query.URL)
-			if siteURL != nil {
-				urlLink.SetURL(siteURL)
-			} else {
-				if err := urlLink.SetURLFromString(query.URL); err != nil {
-					log.Printf("Failed to set URL from string: %v", err)
-				}
-			}
-
-			activeCheck := c.Objects[2].(*widget.Check)
-			deleteButton := c.Objects[3].(*widget.Button)
-
-			sm.SeedBaseline(queryKey, query.Active)
-			activeCheck.SetChecked(query.Active)
-
-			activeCheck.OnChanged = func(b bool) {
-				if b != sm.GetBaseline(queryKey).(bool) {
-					sm.SetSettingChangedCallback(queryKey, func() {
-						var err error
-						if b {
-							err = p.cfg.EnableImageQuery(query.ID)
-						} else {
-							err = p.cfg.DisableImageQuery(query.ID)
-						}
-						if err != nil {
-							log.Printf("Failed to update query status: %v", err)
-						}
-					})
-					sm.SetRefreshFlag(queryKey)
-				} else {
-					sm.RemoveSettingChangedCallback(queryKey)
-					sm.UnsetRefreshFlag(queryKey)
-				}
-				sm.GetCheckAndEnableApplyFunc()()
-			}
-
-			deleteButton.OnTapped = func() {
-				if query.Managed {
-					return // Should be disabled/hidden anyway
-				}
-				d := dialog.NewConfirm("Please Confirm", fmt.Sprintf("Are you sure you want to delete %s?", query.Description), func(b bool) {
-					if b {
-						if query.Active {
-							sm.SetRefreshFlag(queryKey)
-							// Trigger apply check if needed
-							sm.GetCheckAndEnableApplyFunc()()
-						}
-						if err := p.cfg.RemoveImageQuery(query.ID); err != nil {
-							log.Printf("Failed to remove image query: %v", err)
-						}
-						queryList.Refresh()
-					}
-				}, sm.GetSettingsWindow())
-				d.Show()
-			}
-
-			if query.Managed {
-				deleteButton.Disable()
-			} else {
-				deleteButton.Enable()
-			}
-		},
-	)
-	return queryList
+	return wallpaper.CreateQueryList(sm, wallpaper.QueryListConfig{
+		GetQueries:    p.cfg.GetImageQueries,
+		EnableQuery:   p.cfg.EnableImageQuery,
+		DisableQuery:  p.cfg.DisableImageQuery,
+		RemoveQuery:   p.cfg.RemoveImageQuery,
+		GetDisplayURL: p.getWebURL,
+	})
 }
 
 // GetProviderIcon returns the provider's icon for the tray menu.

--- a/pkg/wallpaper/providers/wikimedia/wikimedia.go
+++ b/pkg/wallpaper/providers/wikimedia/wikimedia.go
@@ -15,8 +15,6 @@ import (
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/dialog"
-	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/dixieflatline76/Spice/v2/pkg/provider"
@@ -443,107 +441,30 @@ func (p *WikimediaProvider) CreateQueryPanel(sm setting.SettingsManager, pending
 }
 
 func (p *WikimediaProvider) createImgQueryList(sm setting.SettingsManager) *widget.List {
-	var queryList *widget.List
-	queryList = widget.NewList(
-		func() int {
-			return len(p.cfg.GetWikimediaQueries())
-		},
-		func() fyne.CanvasObject {
-			urlLink := widget.NewHyperlink("Placeholder", nil)
-			queryLabel := widget.NewLabel("Query")
-			activeCheck := widget.NewCheck("Active", nil)
-			deleteButton := widget.NewButton("Delete", nil)
-			// Match Unsplash: Link -> Label -> Spacer -> Check -> Delete
-			return container.NewHBox(urlLink, queryLabel, layout.NewSpacer(), activeCheck, deleteButton)
-		},
-		func(id widget.ListItemID, obj fyne.CanvasObject) {
-			queries := p.cfg.GetWikimediaQueries()
-			if id >= len(queries) {
-				return
-			}
-			q := queries[id]
-			queryKey := q.ID
+	return wallpaper.CreateQueryList(sm, wallpaper.QueryListConfig{
+		GetQueries:    p.cfg.GetWikimediaQueries,
+		EnableQuery:   p.cfg.EnableImageQuery,
+		DisableQuery:  p.cfg.DisableImageQuery,
+		RemoveQuery:   p.cfg.RemoveImageQuery,
+		GetDisplayURL: p.getDisplayURL,
+	})
+}
 
-			c := obj.(*fyne.Container)
-			urlLink := c.Objects[0].(*widget.Hyperlink)
-			queryLabel := c.Objects[1].(*widget.Label)
-			activeCheck := c.Objects[3].(*widget.Check)
-			deleteButton := c.Objects[4].(*widget.Button)
-
-			urlLink.SetText(q.Description)
-			queryLabel.SetText(q.URL) // Show the raw query term (e.g. "category:Space")
-
-			// Construct a valid URL for the hyperlink if possible
-			// The Query URL might be "Category:Foo" or "search:Bar" or a full URL if user entered one?
-			// ParseURL normalizes to "category:..." or "search:...".
-			// We try to make it clickable if it looks like a URL, or construct one.
-			// Wikimedia URLs: https://commons.wikimedia.org/wiki/Category:Nature
-			displayURL := q.URL
-			lowerURL := strings.ToLower(q.URL)
-
-			if strings.HasPrefix(lowerURL, "category:") {
-				// We must escape the category name to handle spaces (e.g. "Deep Space" -> "Deep%20Space")
-				// url.Parse will fail on spaces.
-				// Note: We strip from original q.URL to preserve casing of the category name if needed?
-				// Actually wikimedia categories are case sensitive for the first char usually capitalized, but spaces need encoding.
-				// We need to strip the prefix length carefully.
-				catName := q.URL[9:] // "category:" is 9 chars. Assuming normalized length from lowerURL check matches?
-				// BE CAREFUL: If prefix was "Category:", length is same.
-
-				displayURL = "https://commons.wikimedia.org/wiki/Category:" + url.PathEscape(catName)
-			} else if strings.HasPrefix(lowerURL, "search:") {
-				displayURL = "https://commons.wikimedia.org/w/index.php?search=" + url.QueryEscape(q.URL[7:])
-			}
-
-			if u, err := url.Parse(displayURL); err == nil && u.Scheme != "" {
-				urlLink.SetURL(u)
-			} else {
-				// Fallback if parsing fails or no scheme
-				_ = urlLink.SetURLFromString(displayURL)
-			}
-
-			sm.SeedBaseline(queryKey, q.Active)
-			activeCheck.SetChecked(q.Active)
-
-			activeCheck.OnChanged = func(b bool) {
-				if b != sm.GetBaseline(queryKey).(bool) {
-					sm.SetSettingChangedCallback(queryKey, func() {
-						var err error
-						if b {
-							err = p.cfg.EnableImageQuery(q.ID)
-						} else {
-							err = p.cfg.DisableImageQuery(q.ID)
-						}
-						if err != nil {
-							log.Printf("Failed to update query status: %v", err)
-						}
-					})
-					sm.SetRefreshFlag(queryKey)
-				} else {
-					sm.RemoveSettingChangedCallback(queryKey)
-					sm.UnsetRefreshFlag(queryKey)
-				}
-				sm.GetCheckAndEnableApplyFunc()()
-			}
-
-			deleteButton.OnTapped = func() {
-				dialog.NewConfirm("Delete Query", "Are you sure you want to delete this query?", func(b bool) {
-					if b {
-						if q.Active {
-							sm.SetRefreshFlag(queryKey)
-							sm.GetCheckAndEnableApplyFunc()()
-						}
-						if err := p.cfg.RemoveImageQuery(q.ID); err != nil {
-							dialog.ShowError(err, sm.GetSettingsWindow())
-						}
-						sm.SetRefreshFlag("queries") // Refresh global query list tag
-						queryList.Refresh()
-					}
-				}, sm.GetSettingsWindow()).Show()
-			}
-		},
-	)
-	return queryList
+func (p *WikimediaProvider) getDisplayURL(queryURL string) *url.URL {
+	lowerURL := strings.ToLower(queryURL)
+	var displayURL string
+	if strings.HasPrefix(lowerURL, "category:") {
+		catName := queryURL[9:]
+		displayURL = "https://commons.wikimedia.org/wiki/Category:" + url.PathEscape(catName)
+	} else if strings.HasPrefix(lowerURL, "search:") {
+		displayURL = "https://commons.wikimedia.org/w/index.php?search=" + url.QueryEscape(queryURL[7:])
+	} else {
+		displayURL = queryURL
+	}
+	if u, err := url.Parse(displayURL); err == nil && u.Scheme != "" {
+		return u
+	}
+	return nil
 }
 
 func init() {

--- a/pkg/wallpaper/ui.go
+++ b/pkg/wallpaper/ui.go
@@ -2,16 +2,155 @@ package wallpaper
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	"github.com/dixieflatline76/Spice/v2/pkg/ui/setting"
 	utilLog "github.com/dixieflatline76/Spice/v2/util/log"
 )
+
+// QueryListConfig defines the provider-specific callbacks for a scrollable query list.
+// Providers pass this to CreateQueryList to get a scroll-safe widget.List that
+// correctly handles Fyne's cell recycling without losing pending user toggles.
+type QueryListConfig struct {
+	// GetQueries returns the current list of queries from config.
+	GetQueries func() []ImageQuery
+	// EnableQuery is called on Apply when the user enables a query.
+	EnableQuery func(id string) error
+	// DisableQuery is called on Apply when the user disables a query.
+	DisableQuery func(id string) error
+	// RemoveQuery is called when the user confirms deletion.
+	RemoveQuery func(id string) error
+	// GetDisplayURL converts an API URL to a clickable web URL. Optional.
+	GetDisplayURL func(apiURL string) *url.URL
+}
+
+// CreateQueryList builds a scroll-safe widget.List for query management.
+// It handles baseline seeding, pending state preservation across Fyne cell recycling,
+// and wires up the enable/disable/delete interactions with the SettingsManager.
+func CreateQueryList(sm setting.SettingsManager, cfg QueryListConfig) *widget.List {
+	var queryList *widget.List
+	queryList = widget.NewList(
+		// Length
+		func() int {
+			return len(cfg.GetQueries())
+		},
+		// CreateItem — builds the cell template (no data binding here)
+		func() fyne.CanvasObject {
+			urlLink := widget.NewHyperlink("Placeholder", nil)
+			activeCheck := widget.NewCheck("Active", nil)
+			deleteButton := widget.NewButton("Delete", nil)
+			return container.NewHBox(urlLink, layout.NewSpacer(), activeCheck, deleteButton)
+		},
+		// UpdateItem — binds data to a recycled cell (scroll-safe)
+		func(i int, o fyne.CanvasObject) {
+			queries := cfg.GetQueries()
+			if i >= len(queries) {
+				return
+			}
+			query := queries[i]
+			queryKey := query.ID
+
+			c := o.(*fyne.Container)
+			urlLink := c.Objects[0].(*widget.Hyperlink)
+			activeCheck := c.Objects[2].(*widget.Check)
+			deleteButton := c.Objects[3].(*widget.Button)
+
+			// Set display text and URL
+			urlLink.SetText(query.Description)
+			if cfg.GetDisplayURL != nil {
+				if u := cfg.GetDisplayURL(query.URL); u != nil {
+					urlLink.SetURL(u)
+				}
+			} else {
+				if u, err := url.Parse(query.URL); err == nil {
+					urlLink.SetURL(u)
+				}
+			}
+
+			// --- Scroll-Safe State Management ---
+			// Only seed baseline on first encounter to avoid overwriting pending toggles.
+			if sm.GetBaseline(queryKey) == nil {
+				sm.SeedBaseline(queryKey, query.Active)
+			}
+
+			// MUST clear OnChanged before SetChecked, otherwise recycling a cell
+			// will trigger the previous query's OnChanged callback!
+			activeCheck.OnChanged = nil
+
+			// Restore pending state if user has toggled, otherwise use persisted state.
+			if sm.HasPendingChange(queryKey) {
+				activeCheck.SetChecked(!sm.GetBaseline(queryKey).(bool))
+			} else {
+				activeCheck.SetChecked(query.Active)
+			}
+
+			// Wire checkbox toggle
+			activeCheck.OnChanged = func(b bool) {
+				if b != sm.GetBaseline(queryKey).(bool) {
+					sm.SetSettingChangedCallback(queryKey, func() {
+						var err error
+						if b {
+							err = cfg.EnableQuery(query.ID)
+						} else {
+							err = cfg.DisableQuery(query.ID)
+						}
+
+						if err != nil {
+							utilLog.Printf("Failed to update query status: %v", err)
+						} else {
+							// Update the baseline IF the change was successfully applied.
+							// This prevents the "logic flip" bug if the user interacts
+							// with the list again before reloading the panel.
+							sm.SeedBaseline(queryKey, b)
+
+							// Also update the underlying query data object in the local slice for this cell recycle loop,
+							// just in case, though the config slice is usually re-fetched.
+							query.Active = b
+						}
+					})
+					sm.SetRefreshFlag(queryKey)
+				} else {
+					sm.RemoveSettingChangedCallback(queryKey)
+					sm.UnsetRefreshFlag(queryKey)
+				}
+				sm.GetCheckAndEnableApplyFunc()()
+			}
+
+			// Wire delete button
+			deleteButton.OnTapped = func() {
+				d := dialog.NewConfirm("Please Confirm", fmt.Sprintf("Are you sure you want to delete %s?", query.Description), func(b bool) {
+					if b {
+						if query.Active {
+							sm.SetRefreshFlag(queryKey)
+							sm.GetCheckAndEnableApplyFunc()()
+						}
+						if err := cfg.RemoveQuery(query.ID); err != nil {
+							utilLog.Printf("Failed to remove query: %v", err)
+						}
+						queryList.Refresh()
+					}
+				}, sm.GetSettingsWindow())
+				d.Show()
+			}
+
+			// Managed queries cannot be deleted
+			if query.Managed {
+				deleteButton.Disable()
+			} else {
+				deleteButton.Enable()
+			}
+		},
+	)
+	return queryList
+}
 
 // CreateTrayMenuItems creates the menu items for the tray menu
 func (wp *Plugin) CreateTrayMenuItems() []*fyne.MenuItem {

--- a/pkg/wallpaper/ui_test.go
+++ b/pkg/wallpaper/ui_test.go
@@ -166,6 +166,10 @@ func (m *MockSettingsManager) SetValue(name string, val interface{}) {
 	}
 }
 
+func (m *MockSettingsManager) HasPendingChange(name string) bool {
+	return false
+}
+
 func (m *MockSettingsManager) Refresh() {
 	// No-op for mock
 }

--- a/ui/settings_manager.go
+++ b/ui/settings_manager.go
@@ -122,6 +122,12 @@ func (sm *SettingsManager) GetBaseline(name string) interface{} {
 	return sm.registry[name]
 }
 
+// HasPendingChange returns true if the user has toggled a setting but not yet applied.
+func (sm *SettingsManager) HasPendingChange(name string) bool {
+	_, exists := sm.chgPrefsCallbacks[name]
+	return exists
+}
+
 // CreateApplyButton is a helper function that creates and sets up the Apply Changes button.
 func createApplyButton(sm *SettingsManager) *widget.Button {
 	var applyButton *widget.Button


### PR DESCRIPTION
- Add HasPendingChange to SettingsManager interface
- Create shared CreateQueryList widget to eliminate duplicate recycling bugs
- Add OnChanged unbinding during cell recycling to fix ghost toggles
- Explicitly SeedBaseline after successful apply to fix post-apply logic flip
- Update Wallhaven, Pexels, Wikimedia, and Google Photos providers