### PR TITLE
fix(ui): restore missing targeted shortcuts and hyperlink settings

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -610,39 +610,27 @@ func (sa *SpiceApp) RebuildPreferencesContent(initialTab string) {
 							hotkey.StartListeners(GetPluginManager())
 						},
 					},
-					schema.HorizontalRowItem{
-						ID: "shortcutsIndent",
-						Items: []schema.ItemSchema{
-							schema.LabelItem{ID: "shortcutsSpacer", Text: "      "},
-							schema.BoolItem{
-								Name:         "enableTargetedShortcuts",
-								InitialValue: !wallpaper.GetInstance().GetTargetedShortcutsDisabled(),
-								Label:        i18n.T("Enable Display Specific Shortcuts (Alt + Arrow + 1-9):"),
-								Help:         i18n.T("Disable this if Alt+Arrow conflicts with your browser or other apps."),
-								ApplyFunc: func(val bool) {
-									wallpaper.GetInstance().SetTargetedShortcutsDisabled(!val)
-									hotkey.StartListeners(GetPluginManager())
-								},
-								EnabledIf: func() bool {
-									val := sm.GetValue("enableShortcuts")
-									if val == nil {
-										return true
-									}
-									return val.(bool)
-								},
-							},
+					schema.BoolItem{
+						Name:         "enableTargetedShortcuts",
+						InitialValue: !wallpaper.GetInstance().GetTargetedShortcutsDisabled(),
+						Label:        i18n.T("Enable Display Specific Shortcuts (Alt + Arrow + 1-9):"),
+						Help:         i18n.T("Disable this if Alt+Arrow conflicts with your browser or other apps."),
+						ApplyFunc: func(val bool) {
+							wallpaper.GetInstance().SetTargetedShortcutsDisabled(!val)
+							hotkey.StartListeners(GetPluginManager())
+						},
+						EnabledIf: func() bool {
+							val := sm.GetValue("enableShortcuts")
+							if val == nil {
+								return true
+							}
+							return val.(bool)
 						},
 					},
-					schema.HorizontalRowItem{
-						ID: "shortcutsLinkRow",
-						Items: []schema.ItemSchema{
-							schema.LabelItem{ID: "shortcutsLinkSpacer", Text: "      "},
-							schema.HyperlinkItem{
-								ID:   "shortcutsLink",
-								Text: i18n.T("View all shortcuts →"),
-								URL:  "https://github.com/dixieflatline76/Spice/blob/main/docs/user_guide.md#keyboard-shortcuts",
-							},
-						},
+					schema.HyperlinkItem{
+						ID:   "shortcutsLink",
+						Text: i18n.T("View all shortcuts →"),
+						URL:  "https://github.com/dixieflatline76/Spice/blob/main/docs/user_guide.md#keyboard-shortcuts",
 					},
 					schema.SelectItem{
 						Name:         "theme",


### PR DESCRIPTION
## Description
The `enableTargetedShortcuts` checkbox and "View all shortcuts →" hyperlink were wrapped in `HorizontalRowItem` containers to achieve visual indentation beneath the parent "Enable global shortcuts" setting. However, `renderHorizontalRow` in `settings_manager.go` only handled `TextItem`, `ButtonItem`, `ConfirmButtonItem`, and `LabelItem` types — it silently dropped `BoolItem` and `HyperlinkItem`, causing both controls to disappear from the preferences panel.

The fix promotes both items to top-level schema entries, bypassing `renderHorizontalRow` entirely. The `EnabledIf` dependency on the parent checkbox is preserved, so the targeted shortcuts toggle still greys out when global shortcuts are disabled.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Verified the targeted shortcuts checkbox and hyperlink now render correctly on the App preferences tab
- Confirmed `EnabledIf` correctly disables the targeted shortcuts checkbox when global shortcuts are unchecked
- `go build ./...` compiles cleanly
- `go test ./ui/... ./pkg/wallpaper/...` — all tests pass

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
