### PR TITLE
fix: App Store sandbox crash + prerelease CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   release:
-    types: [published]
+    types: [published, released]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -69,7 +69,7 @@ jobs:
   build-win:
     name: Build Windows
     runs-on: windows-latest
-    if: github.event_name == 'release'
+    if: github.event.action == 'published'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
   build-mac:
     name: Build macOS
     runs-on: macos-latest
-    if: github.event_name == 'release'
+    if: github.event.action == 'published'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -259,7 +259,7 @@ jobs:
     name: Publish Release
     runs-on: windows-latest
     needs: [build-win, build-mac]
-    if: github.event_name == 'release'
+    if: github.event.action == 'published'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -338,3 +338,40 @@ jobs:
         run: go run cmd/util/spice_releaser/main.go
         env:
           SPICE_RELEASER_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          SKIP_DISTRIBUTION: ${{ github.event.release.prerelease }}
+
+  distribute-release:
+    name: Distribute (Prerelease Promotion)
+    runs-on: windows-latest
+    if: github.event.action == 'released' && github.event.release.prerelease == false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache: true
+
+      - name: Download Release Assets
+        run: |
+          $tagName = '${{ github.event.release.tag_name }}'
+          $version = $tagName -replace '^v'
+          New-Item -ItemType Directory -Force -Path bin
+          New-Item -ItemType Directory -Force -Path dist
+
+          gh release download $tagName --pattern "Spice-*-windows-amd64.exe" --dir bin
+          gh release download $tagName --pattern "Spice-Setup-*-windows-amd64.exe" --dir bin
+          gh release download $tagName --pattern "Spice-*-macos-arm64.dmg" --dir dist
+          gh release download $tagName --pattern "Spice-Extension-*-chrome.zip" --dir dist
+          gh release download $tagName --pattern "Spice-Extension-*-firefox.zip" --dir dist
+        env:
+          GH_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+        shell: pwsh
+
+      - name: Run Spice Releaser
+        run: go run cmd/util/spice_releaser/main.go
+        env:
+          SPICE_RELEASER_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+

--- a/cmd/spice/main.go
+++ b/cmd/spice/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -19,25 +20,40 @@ import (
 
 var version = "0.0.0"
 
+// breadcrumb writes a diagnostic message to stderr for sysdiagnose capture.
+// These bypass the file logger and appear in Console.app, allowing DTS engineers
+// to see exactly where the app dies during App Store review.
+func breadcrumb(msg string) {
+	fmt.Fprintf(os.Stderr, "[Spice:%s] %s\n", version, msg)
+}
+
 func init() {
 	config.AppVersion = version
 }
 
 func main() {
+	breadcrumb("main() entered")
+
 	// Create a mutex to ensure only one instance is running
 	ok, err := acquireLock()
 	if err != nil {
+		breadcrumb(fmt.Sprintf("acquireLock failed: %v", err))
 		log.Fatalf("Failed to launch: %v", err)
 	}
 	if !ok {
-		fmt.Println("Another instance of Wallhavener is already running.")
+		breadcrumb("acquireLock returned false — another instance detected")
+		fmt.Println("Another instance of Spice is already running.")
 		return
 	}
 	defer releaseLock() // Make sure to release the lock when done
+	breadcrumb("lock acquired")
 
 	spiceApp := ui.GetApplication() // Create a new Fyne application
-	pm := ui.GetPluginManager()     // Get the plugin manager
-	wallpaper.LoadPlugin(pm)        // Initialize the wallpaper plugin
+	breadcrumb("UI application initialized")
+
+	pm := ui.GetPluginManager() // Get the plugin manager
+	wallpaper.LoadPlugin(pm)    // Initialize the wallpaper plugin
+	breadcrumb("wallpaper plugin loaded")
 
 	// --- BROWSER INTEGRATION START ---
 	// Start the Local API Server
@@ -93,5 +109,6 @@ func main() {
 		hotkey.StartListeners(ui.GetPluginManager())
 	}()
 
+	breadcrumb("entering Fyne event loop")
 	spiceApp.Start() // Run the application
 }

--- a/cmd/spice/mutex_unix.go
+++ b/cmd/spice/mutex_unix.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,8 @@ var (
 )
 
 // acquireLock tries to acquire a single-instance lock (file lock on Unix).
+// If the lock mechanism itself fails (e.g. sandbox restrictions), the app
+// proceeds anyway — Apple enforces single instance for App Store apps.
 func acquireLock() (bool, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
@@ -32,7 +35,9 @@ func acquireLock() (bool, error) {
 	lockFilePath := filepath.Join(cacheDir, config.AppName+".lock")
 	file, err := os.OpenFile(lockFilePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
-		return false, errors.New("another instance is already running")
+		// Can't create lock file (sandbox/permissions). Proceed without lock.
+		fmt.Fprintf(os.Stderr, "[Spice] Warning: cannot create lock file %s: %v. Proceeding without single-instance lock.\n", lockFilePath, err)
+		return true, nil
 	}
 
 	//Try to get an exclusive lock. FcntlFlock implements a simple file locker.
@@ -45,12 +50,14 @@ func acquireLock() (bool, error) {
 
 	if err != nil {
 		if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EACCES) {
-			// Another instance is running, lock is BUSY
-			file.Close() // Close the file if we failed to acquire the lock
+			// Another instance is genuinely running, lock is BUSY
+			file.Close()
 			return false, nil
 		}
+		// Unexpected lock error (sandbox?). Proceed without lock.
+		fmt.Fprintf(os.Stderr, "[Spice] Warning: FcntlFlock failed: %v. Proceeding without single-instance lock.\n", err)
 		file.Close()
-		return false, errors.New("another instance is already running")
+		return true, nil
 	}
 
 	lockFile = file

--- a/cmd/util/spice_releaser/main.go
+++ b/cmd/util/spice_releaser/main.go
@@ -113,6 +113,12 @@ func main() {
 		uploadAsset(ctx, client, release.GetID(), file)
 	}
 
+	// Check if we should skip package manager distribution (prerelease builds)
+	if strings.EqualFold(os.Getenv("SKIP_DISTRIBUTION"), "true") {
+		log.Println("SKIP_DISTRIBUTION=true — skipping Homebrew and Winget updates. Assets uploaded successfully! 🚀")
+		return
+	}
+
 	// 3. Homebrew Cask Automation
 	caskTmpl := `cask "spice" do
   arch arm: "arm64", intel: "x86_64"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	fyne.io/systray v1.12.0 // indirect
+	fyne.io/systray v1.12.1 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fyne.io/fyne/v2 v2.7.3 h1:xBT/iYbdnNHONWO38fZMBrVBiJG8rV/Jypmy4tVfRWE=
 fyne.io/fyne/v2 v2.7.3/go.mod h1:gu+dlIcZWSzKZmnrY8Fbnj2Hirabv2ek+AKsfQ2bBlw=
-fyne.io/systray v1.12.0 h1:CA1Kk0e2zwFlxtc02L3QFSiIbxJ/P0n582YrZHT7aTM=
-fyne.io/systray v1.12.0/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
+fyne.io/systray v1.12.1 h1:ygBD6aZXwiOmZoY5N+ukbH9pih0Kq6fYgVeMYbr5skQ=
+fyne.io/systray v1.12.1/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/pkg/wallpaper/config.go
+++ b/pkg/wallpaper/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/user"
 	"path/filepath"
 	"sync"
@@ -116,7 +117,18 @@ func GetConfig(p fyne.Preferences) *Config {
 	cfgOnce.Do(func() {
 		u, e := user.Current()
 		if e != nil {
-			log.Fatalf("failed to initialize %s: %s", config.AppName, e)
+			// App Sandbox may restrict user database access (getpwuid_r).
+			// Fall back to environment variables instead of crashing.
+			log.Printf("Warning: user.Current() failed: %s. Using environment fallback.", e)
+			uid := os.Getenv("UID")
+			if uid == "" {
+				uid = "sandbox-user"
+			}
+			username := os.Getenv("USER")
+			if username == "" {
+				username = "sandbox"
+			}
+			u = &user.User{Uid: uid, Username: username}
 		}
 		cfgInstance = &Config{
 			Preferences:        p,

--- a/pkg/wallpaper/wallpaper.go
+++ b/pkg/wallpaper/wallpaper.go
@@ -373,7 +373,7 @@ func (wp *Plugin) Activate() {
 	wp.jobSubmitter = wp.pipeline
 
 	if err := wp.fm.EnsureDirs(); err != nil {
-		log.Fatalf("Error ensuring directories: %v", err)
+		log.Printf("Warning: Error ensuring directories: %v. Some features may be limited.", err)
 	}
 
 	if err := wp.store.LoadCache(); err != nil {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -8,6 +8,7 @@ import (
 	"image/draw"
 	"image/gif"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -131,11 +132,17 @@ func GetApplication() ui.App {
 func getInstance() *SpiceApp {
 	// Create a new instance of the application if it doesn't exist
 	saOnce.Do(func() {
+		fmt.Fprintln(os.Stderr, "[Spice] getInstance: starting")
+
 		// Initialize the wallpaper service for right OS
 		currentOS := getOS()
+		fmt.Fprintln(os.Stderr, "[Spice] getInstance: OS interface created")
 
 		a := app.NewWithID(config.AppName)
+		fmt.Fprintln(os.Stderr, "[Spice] getInstance: Fyne app created")
+
 		if _, ok := a.(desktop.App); ok {
+			fmt.Fprintln(os.Stderr, "[Spice] getInstance: desktop.App confirmed")
 
 			saInstance = &SpiceApp{
 				App:      a,
@@ -149,6 +156,7 @@ func getInstance() *SpiceApp {
 				tabItems: make(map[string]*container.TabItem),
 			}
 			saInstance.appConfig = config.NewAppConfig(saInstance.Preferences())
+			fmt.Fprintln(os.Stderr, "[Spice] getInstance: app config loaded")
 
 			// Apply saved debug logging preference
 			if saInstance.appConfig.GetDebugLoggingEnabled() {
@@ -168,8 +176,10 @@ func getInstance() *SpiceApp {
 			default:
 				saInstance.Settings().SetTheme(theme.DefaultTheme())
 			}
+			fmt.Fprintln(os.Stderr, "[Spice] getInstance: theme applied")
 
 			saInstance.verifyEULA()
+			fmt.Fprintln(os.Stderr, "[Spice] getInstance: EULA verified")
 
 			// Setup OS-specific lifecycle hooks (e.g. Chrome OS Pseudo-Tray)
 			saInstance.os.SetupLifecycle(saInstance.App, saInstance)
@@ -183,7 +193,9 @@ func getInstance() *SpiceApp {
 					wp.SyncMonitors(false)
 				}
 			})
+			fmt.Fprintln(os.Stderr, "[Spice] getInstance: lifecycle hooks set")
 		} else {
+			fmt.Fprintln(os.Stderr, "[Spice] getInstance: FATAL — not a desktop.App")
 			utilLog.Fatal("Spice not supported on this platform")
 		}
 	})


### PR DESCRIPTION
## Description
Resolves the silent crash-on-launch that Apple App Store reviewers have been reporting across 3 submission attempts. The crash is a voluntary `os.Exit(1)` triggered by `log.Fatalf` calls in the startup path when running inside an App Sandbox container on a clean system.

**Root cause:** Several init-path functions (`user.Current()`, `acquireLock()`, `EnsureDirs()`) call `log.Fatalf` on failure, which calls `os.Exit(1)`. In a sandboxed App Store environment, these system calls can fail due to restricted user database access or filesystem permissions — killing the app before any UI is shown and producing no crash report.

**Additionally**, this PR adds prerelease support to the CI pipeline so we can ship TestFlight builds to the DTS engineer without pushing to winget/brew.

Fixes #(App Store rejection — Guideline 2.1.0 Performance: App Completeness)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Built appstore-tagged binary (`make build-darwin-appstore-arm64`) on macOS Apple Silicon
- Ran binary directly — all stderr breadcrumbs fire in correct order through to Fyne event loop
- Verified tray icon appears and wallpaper rotation functions normally
- All existing unit tests pass (`go test ./...`)
- Standard (non-appstore) build verified to confirm no regression
- **Pending:** TestFlight build to DTS engineer Travis for sysdiagnose capture in actual sandbox environment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
