### PR TITLE
fix: use sandbox-safe cache directory for wallpaper downloads

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -22,9 +22,17 @@ var LogSubDir = "." + strings.ToLower(AppName)
 // LogExt is the extension for the log files.
 var LogExt = ".log"
 
-// GetWorkingDir returns the working directory for the service.
+// GetWorkingDir returns the working directory for transient/cache data.
+// Uses os.UserCacheDir() which is sandbox-safe on macOS and idiomatic on all platforms:
+//   - macOS: ~/Library/Caches (sandbox auto-maps to container)
+//   - Windows: %LocalAppData%
+//   - Linux: ~/.cache (XDG_CACHE_HOME)
 func GetWorkingDir() string {
-	return filepath.Join(os.TempDir(), strings.ToLower(AppName))
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir() // Fallback
+	}
+	return filepath.Join(cacheDir, strings.ToLower(AppName))
 }
 
 var appDir string


### PR DESCRIPTION
## Description
Replace `os.TempDir()` with `os.UserCacheDir()` in `config.GetWorkingDir()`. The macOS App Sandbox blocks access to `/var/folders/.../T/` (returned by `os.TempDir()`), causing **every file operation** — downloads, caching, fitted images, pagination state — to fail with `operation not permitted`.

TestFlight logs confirmed the app now launches successfully in the sandbox (crash fix from #previous PR), but all wallpaper downloads fail because the working directory is inaccessible.

`os.UserCacheDir()` returns sandbox-safe paths on all platforms:
- **macOS**: `~/Library/Caches` (auto-mapped to container by sandbox)
- **Windows**: `%LocalAppData%` (more persistent than `%TEMP%`)
- **Linux**: `~/.cache` (XDG compliant)

This is a single-function change that propagates to all callers automatically.

Fixes #(App Store sandbox — wallpaper downloads fail with operation not permitted)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `go build ./...` — compiles cleanly
- `go test ./config/... ./pkg/wallpaper/...` — all tests pass (10 packages, 0 failures)
- Verified `os.UserCacheDir()` behavior confirmed via Apple documentation and Go standard library docs
- **Pending**: TestFlight build to verify wallpaper rotation works in actual sandbox environment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
