### PR TITLE
fix: hide Dock icon in App Store build using lifecycle hook

### DIFF
--- a/ui/ui_eula_appstore.go
+++ b/ui/ui_eula_appstore.go
@@ -3,6 +3,8 @@
 package ui
 
 import (
+	"time"
+
 	"github.com/dixieflatline76/Spice/v2/util"
 	utilLog "github.com/dixieflatline76/Spice/v2/util/log"
 )
@@ -21,4 +23,16 @@ func (sa *SpiceApp) verifyEULA() {
 	// We specifically do NOT call CreateSplashScreen here.
 	// This ensures the app starts silently in the tray, avoiding OpenGL window creation
 	// until the user (or reviewer) explicitly requests a windowed feature.
+
+	// Hide the Dock icon after Fyne/GLFW finishes initialization.
+	// GLFW forces the activation policy to Regular during startup, overriding LSUIElement.
+	// In the standard build, CreateSplashScreen handles this via TransformToBackground()
+	// after the splash timer. Since we skip splash, we use the lifecycle hook instead.
+	sa.Lifecycle().SetOnStarted(func() {
+		go func() {
+			time.Sleep(200 * time.Millisecond) // Wait for GLFW to finish forcing Regular policy
+			sa.os.TransformToBackground()
+			utilLog.Print("App Store: Dock icon hidden (activation policy set to Accessory)")
+		}()
+	})
 }


### PR DESCRIPTION
## Description
GLFW forces the activation policy to `NSApplicationActivationPolicyRegular` during startup, overriding `LSUIElement=true` in the Info.plist. In the standard (DMG) build, `CreateSplashScreen` handles this by calling `TransformToBackground()` after the splash timer, which sets the policy back to `Accessory` and hides the Dock icon.

The App Store build skips the splash screen entirely (to avoid potential OpenGL issues in review VMs), so `TransformToBackground()` was never called — leaving the Dock icon permanently visible.

This fix uses `Lifecycle().SetOnStarted()` with a 200ms delay to call `TransformToBackground()` after GLFW finishes initialization, hiding the Dock icon without requiring a splash window.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `go build ./...` — compiles cleanly
- Verified that `TransformToBackground()` successfully hides the Dock icon on macOS by testing via the About Spice dialog (open → Dock icon appears, close → Dock icon hides)
- **Pending**: TestFlight build to confirm the lifecycle hook fires at the correct time in the sandboxed environment

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
