### PR TITLE
fix: nightly grooming cache starvation, zombie recovery, and OpenGL probe caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,13 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
+        timeout-minutes: 10
         with:
           version: v1.64.6
-          args: --out-format=colored-line-number ./...
+          args: --out-format=colored-line-number --timeout=10m ./...
           install-mode: goinstall # Build from source using Go 1.25 to prevent version panic
         env:
-           GOGC: 10
+           GOGC: 100
            CGO_ENABLED: 1
 
       - name: Run tests

--- a/pkg/i18n/translations/de.json
+++ b/pkg/i18n/translations/de.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Quelle: Wird initialisiert...",
   "Source: {{.Provider}}": "Quelle: {{.Provider}}",
   "Spice EULA": "Spice-EULA",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice benötigt OpenGL 2.0+ oder Hardwarebeschleunigung, um Fenster anzuzeigen. Die Anwendung läuft weiterhin im Hintergrund, aber die Benutzeroberfläche ist möglicherweise nicht verfügbar.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice benötigt OpenGL 2.0+ oder Hardwarebeschleunigung, um Fenster anzuzeigen. Die Anwendung läuft weiterhin im Hintergrund, aber die Benutzeroberfläche ist möglicherweise nicht verfügbar.",
   "Spice: Update Available": "Spice: Update verfügbar",
   "Stagger monitor changes:": "Bildschirmwechsel staffeln:",
   "Status: Authorized (Ready to Select)": "Status: Autorisiert (Bereit zur Auswahl)",

--- a/pkg/i18n/translations/en.json
+++ b/pkg/i18n/translations/en.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Source: Initializing...",
   "Source: {{.Provider}}": "Source: {{.Provider}}",
   "Spice EULA": "Spice EULA",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.",
   "Spice: Update Available": "Spice: Update Available",
   "Stagger monitor changes:": "Stagger monitor changes:",
   "Status: Authorized (Ready to Select)": "Status: Authorized (Ready to Select)",

--- a/pkg/i18n/translations/es.json
+++ b/pkg/i18n/translations/es.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Fuente: Inicializando...",
   "Source: {{.Provider}}": "Fuente: {{.Provider}}",
   "Spice EULA": "EULA de Spice",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice requiere OpenGL 2.0+ o aceleración por hardware para mostrar ventanas. La aplicación seguirá ejecutándose en segundo plano, pero la interfaz de usuario podría no estar disponible.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice requiere OpenGL 2.0+ o aceleración por hardware para mostrar ventanas. La aplicación seguirá ejecutándose en segundo plano, pero la interfaz de usuario podría no estar disponible.",
   "Spice: Update Available": "Spice: Actualización disponible",
   "Stagger monitor changes:": "Escalonar cambios de monitor:",
   "Status: Authorized (Ready to Select)": "Estado: Autorizado (listo para seleccionar)",

--- a/pkg/i18n/translations/fr.json
+++ b/pkg/i18n/translations/fr.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Source : Initialisation...",
   "Source: {{.Provider}}": "Source : {{.Provider}}",
   "Spice EULA": "CLUF de Spice",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice nécessite OpenGL 2.0+ ou une accélération matérielle pour afficher les fenêtres. L'application continuera de s'exécuter en arrière-plan, mais l'interface utilisateur pourrait être indisponible.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice nécessite OpenGL 2.0+ ou une accélération matérielle pour afficher les fenêtres. L'application continuera de s'exécuter en arrière-plan, mais l'interface utilisateur pourrait être indisponible.",
   "Spice: Update Available": "Spice : Mise à jour disponible",
   "Stagger monitor changes:": "Échelonner les changements d'écran :",
   "Status: Authorized (Ready to Select)": "État : Autorisé (Prêt pour la sélection)",

--- a/pkg/i18n/translations/it.json
+++ b/pkg/i18n/translations/it.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Sorgente: Inizializzazione...",
   "Source: {{.Provider}}": "Sorgente: {{.Provider}}",
   "Spice EULA": "EULA di Spice",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice richiede OpenGL 2.0+ o l'accelerazione hardware per mostrare le finestre. L'applicazione continuerà a funzionare in background, ma l'interfaccia utente potrebbe non essere disponibile.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice richiede OpenGL 2.0+ o l'accelerazione hardware per mostrare le finestre. L'applicazione continuerà a funzionare in background, ma l'interfaccia utente potrebbe non essere disponibile.",
   "Spice: Update Available": "Spice: Aggiornamento disponibile",
   "Stagger monitor changes:": "Sfalsa i cambiamenti dello schermo:",
   "Status: Authorized (Ready to Select)": "Stato: Autorizzato (Pronto per la selezione)",

--- a/pkg/i18n/translations/ja.json
+++ b/pkg/i18n/translations/ja.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "ソース：初期化中...",
   "Source: {{.Provider}}": "ソース: {{.Provider}}",
   "Spice EULA": "Spice 使用許諾書",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spiceがウィンドウを表示するには、OpenGL 2.0以上またはハードウェアアクセラレーションが必要です。アプリはバックグラウンドで実行され続けますが、ユーザーインターフェースが利用できない場合があります。",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spiceがウィンドウを表示するには、OpenGL 2.0以上またはハードウェアアクセラレーションが必要です。アプリはバックグラウンドで実行され続けますが、ユーザーインターフェースが利用できない場合があります。",
   "Spice: Update Available": "Spice：アップデートが利用可能です",
   "Stagger monitor changes:": "モニターの変更をずらす:",
   "Status: Authorized (Ready to Select)": "ステータス: 承認済み (選択準備完了)",

--- a/pkg/i18n/translations/pseudo.json
+++ b/pkg/i18n/translations/pseudo.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "[!! Soouurcee: IIniitiiaaliiziing... !!]",
   "Source: {{.Provider}}": "[!! Soouurcee: {{.Provider}} !!]",
   "Spice EULA": "[!! Spiicee EEUULAA !!]",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "[!! Spiicee reequuiirees OOpeenGL 2.0+ oor haardwaaree aacceeleeraatiioon too shoow wiindoows. Thee aappliicaatiioon wiill coontiinuuee too ruun iin thee baackgroouund, buut thee uuseer iinteerfaacee maay bee uunaavaaiilaablee. !!]",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "[!! Spiicee reequuiirees OOpeenGL 2.0+ oor haardwaaree aacceeleeraatiioon too shoow wiindoows. Thee aappliicaatiioon wiill coontiinuuee too ruun iin thee baackgroouund. Pleeaasee try reebooootiing yoouur maachiinee too reestooree graaphiics fuunctiioonaaliity. !!]",
   "Spice: Update Available": "[!! Spiicee: UUpdaatee AAvaaiilaablee !!]",
   "Stagger monitor changes:": "[!! Staaggeer mooniitoor chaangees: !!]",
   "Status: Authorized (Ready to Select)": "[!! Staatuus: AAuuthooriizeed (Reeaady too Seeleect) !!]",

--- a/pkg/i18n/translations/pseudo.json
+++ b/pkg/i18n/translations/pseudo.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "[!! Soouurcee: IIniitiiaaliiziing... !!]",
   "Source: {{.Provider}}": "[!! Soouurcee: {{.Provider}} !!]",
   "Spice EULA": "[!! Spiicee EEUULAA !!]",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "[!! Spiicee reequuiirees OOpeenGL 2.0+ oor haardwaaree aacceeleeraatiioon too shoow wiindoows. Thee aappliicaatiioon wiill coontiinuuee too ruun iin thee baackgroouund, buut thee uuseer iinteerfaacee maay bee uunaavaaiilaablee. !!]",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "[!! Spiicee reequuiirees OOpeenGL 2.0+ oor haardwaaree aacceeleeraatiioon too shoow wiindoows. Thee aappliicaatiioon wiill coontiinuuee too ruun iin thee baackgroouund, buut thee uuseer iinteerfaacee maay bee uunaavaaiilaablee. !!]",
   "Spice: Update Available": "[!! Spiicee: UUpdaatee AAvaaiilaablee !!]",
   "Stagger monitor changes:": "[!! Staaggeer mooniitoor chaangees: !!]",
   "Status: Authorized (Ready to Select)": "[!! Staatuus: AAuuthooriizeed (Reeaady too Seeleect) !!]",

--- a/pkg/i18n/translations/pt.json
+++ b/pkg/i18n/translations/pt.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Origem: A inicializar...",
   "Source: {{.Provider}}": "Origem: {{.Provider}}",
   "Spice EULA": "EULA do Spice",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "O Spice requer OpenGL 2.0+ ou aceleração de hardware para exibir janelas. O aplicativo continuará a ser executado em segundo plano, mas a interface do usuário poderá ficar indisponível.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "O Spice requer OpenGL 2.0+ ou aceleração de hardware para exibir janelas. O aplicativo continuará a ser executado em segundo plano, mas a interface do usuário poderá ficar indisponível.",
   "Spice: Update Available": "Spice: Atualização Disponível",
   "Stagger monitor changes:": "Alternar mudanças de monitor:",
   "Status: Authorized (Ready to Select)": "Estado: Autorizado (Pronto para Selecionar)",

--- a/pkg/i18n/translations/ru.json
+++ b/pkg/i18n/translations/ru.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Источник: Инициализация...",
   "Source: {{.Provider}}": "Источник: {{.Provider}}",
   "Spice EULA": "EULA Spice",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice требуется OpenGL 2.0+ или аппаратное ускорение для отображения окон. Приложение продолжит работать в фоновом режиме, но пользовательский интерфейс может быть недоступен.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice требуется OpenGL 2.0+ или аппаратное ускорение для отображения окон. Приложение продолжит работать в фоновом режиме, но пользовательский интерфейс может быть недоступен.",
   "Spice: Update Available": "Spice: Доступно обновление",
   "Stagger monitor changes:": "Раздельная смена на мониторах:",
   "Status: Authorized (Ready to Select)": "Статус: Авторизовано (Готово к выбору)",

--- a/pkg/i18n/translations/uk.json
+++ b/pkg/i18n/translations/uk.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "Джерело: Ініціалізація...",
   "Source: {{.Provider}}": "Джерело: {{.Provider}}",
   "Spice EULA": "EULA Spice",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice потребує OpenGL 2.0+ або апаратне прискорення для відображення вікон. Додаток продовжуватиме працювати у фоновому режимі, але інтерфейс користувача може бути недоступним.",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice потребує OpenGL 2.0+ або апаратне прискорення для відображення вікон. Додаток продовжуватиме працювати у фоновому режимі, але інтерфейс користувача може бути недоступним.",
   "Spice: Update Available": "Spice: Доступне оновлення",
   "Stagger monitor changes:": "Роздільна зміна на моніторах:",
   "Status: Authorized (Ready to Select)": "Статус: Авторизовано (Готово до вибору)",

--- a/pkg/i18n/translations/zh-Hant.json
+++ b/pkg/i18n/translations/zh-Hant.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "來源：正在初始化...",
   "Source: {{.Provider}}": "來源：{{.Provider}}",
   "Spice EULA": "Spice 最終使用者授權合約",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice 需要 OpenGL 2.0+ 或硬體加速才能顯示視窗。應用程式將繼續在背景執行，但使用者介面可能無法使用。",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice 需要 OpenGL 2.0+ 或硬體加速才能顯示視窗。應用程式將繼續在背景執行，但使用者介面可能無法使用。",
   "Spice: Update Available": "Spice：有可用更新",
   "Stagger monitor changes:": "交替顯示器更換：",
   "Status: Authorized (Ready to Select)": "狀態：已授權（準備選擇）",

--- a/pkg/i18n/translations/zh.json
+++ b/pkg/i18n/translations/zh.json
@@ -192,7 +192,7 @@
   "Source: Initializing...": "来源：正在初始化...",
   "Source: {{.Provider}}": "来源：{{.Provider}}",
   "Spice EULA": "Spice 最终用户许可协议",
-  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable.": "Spice 需要 OpenGL 2.0+ 或硬件加速才能显示窗口。应用程序将继续在后台运行，但用户界面可能无法使用。",
+  "Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality.": "Spice 需要 OpenGL 2.0+ 或硬件加速才能显示窗口。应用程序将继续在后台运行，但用户界面可能无法使用。",
   "Spice: Update Available": "Spice：有可用更新",
   "Stagger monitor changes:": "交错显示器更换：",
   "Status: Authorized (Ready to Select)": "状态：已授权（准备选择）",

--- a/pkg/sysinfo/windows.go
+++ b/pkg/sysinfo/windows.go
@@ -6,6 +6,7 @@ package sysinfo
 import (
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -71,10 +72,21 @@ func IsRemoteSession() bool {
 // an OpenGL window, we cannot simply use recover() in the main app.
 // Instead, we spawn ourselves as a subprocess with a special flag. If the subprocess
 // exits with 0, OpenGL works. If it exits with 1, OpenGL failed.
-// We run this dynamically every time to catch state changes (e.g. RDP reconnects).
+//
+// The probe runs once at first call and the result is cached for the lifetime of
+// the process. If OpenGL state changes mid-session (e.g. RDP reconnect, driver
+// crash), the user should restart Spice.
 func CanCreateWindows() bool {
-	return probeOpenGLSubprocess()
+	glProbeOnce.Do(func() {
+		glProbeResult = probeOpenGLSubprocess()
+	})
+	return glProbeResult
 }
+
+var (
+	glProbeOnce   sync.Once
+	glProbeResult bool
+)
 
 func probeOpenGLSubprocess() bool {
 

--- a/pkg/wallpaper/scheduler.go
+++ b/pkg/wallpaper/scheduler.go
@@ -96,12 +96,7 @@ func (wp *Plugin) checkAndRunRefresh(now time.Time, lastRefreshDay int, isInitia
 
 		// Maintenance: Grooming & Cleanup
 		log.Print("Nightly Maintenance: Starting cache grooming...")
-		targetFlags := map[string]bool{
-			"SmartFit": wp.cfg.GetSmartFit(),
-			"FaceCrop": wp.cfg.GetFaceCropEnabled(),
-		}
-		// Sync Store (Groom old images)
-		wp.store.Sync(int(wp.cfg.GetCacheSize().Size()), targetFlags, wp.cfg.GetActiveQueryIDs())
+		wp.syncStoreWithConfig()
 
 		// Cleanup Orphans (Delete unknown files)
 		// We get known IDs from store (thread-safe)

--- a/pkg/wallpaper/store.go
+++ b/pkg/wallpaper/store.go
@@ -690,6 +690,16 @@ func (s *ImageStore) determineSyncAction(img provider.Image, activeQueryIDs map[
 		}
 	}
 
+	// Recovery: Detect zombie images from prior invalidation bugs.
+	// If an image has a master file and matching flags but zero derivatives,
+	// it was corrupted by the old flagsMatch length-comparison bug and is
+	// permanently invisible to monitors. Delete it so the fetcher can
+	// re-download and reprocess it on the next cycle.
+	if len(img.DerivativePaths) == 0 {
+		log.Debugf("[Sync] Recovery: deleting zombie image %s (master exists, flags match, but no derivatives)", img.ID)
+		return ImageActionDelete
+	}
+
 	return ImageActionKeep
 }
 

--- a/pkg/wallpaper/store.go
+++ b/pkg/wallpaper/store.go
@@ -724,11 +724,22 @@ func (s *ImageStore) masterFileExists(id string) bool {
 }
 
 func (s *ImageStore) flagsMatch(img provider.Image, target map[string]bool) bool {
-	if len(img.ProcessingFlags) != len(target) {
-		return false
-	}
+	// Compare only the processing-mode keys from `target`.
+	// img.ProcessingFlags may also contain "incompatible:<WxH>" metadata tags
+	// that are NOT part of the processing mode, so a strict length comparison
+	// would always fail for images that have any incompatibility tags.
 	for k, v := range target {
 		if img.ProcessingFlags[k] != v {
+			return false
+		}
+	}
+	// Reverse check: ensure the image doesn't have processing-mode keys
+	// that aren't in target (guards against future flag additions).
+	for k, v := range img.ProcessingFlags {
+		if strings.HasPrefix(k, "incompatible:") {
+			continue // skip metadata tags
+		}
+		if target[k] != v {
 			return false
 		}
 	}

--- a/pkg/wallpaper/store_strict_test.go
+++ b/pkg/wallpaper/store_strict_test.go
@@ -21,7 +21,7 @@ func TestStrictSync_LegacySafety(t *testing.T) {
 	store.SetFileManager(fm, cacheFile)
 
 	// Setup: Image with a SourceID
-	img1 := provider.Image{ID: "img1", SourceQueryID: "q1", FilePath: filepath.Join(tmpDir, "img1.jpg")}
+	img1 := provider.Image{ID: "img1", SourceQueryID: "q1", FilePath: filepath.Join(tmpDir, "img1.jpg"), DerivativePaths: map[string]string{"1920x1080": "d1.jpg"}}
 	assert.NoError(t, os.WriteFile(img1.FilePath, []byte("data"), 0644))
 	store.Add(img1)
 
@@ -49,9 +49,9 @@ func TestStrictSync_UncheckAll(t *testing.T) {
 	store.SetFileManager(fm, cacheFile)
 
 	// img1: From q1
-	img1 := provider.Image{ID: "img1", SourceQueryID: "q1", FilePath: filepath.Join(tmpDir, "img1.jpg")}
+	img1 := provider.Image{ID: "img1", SourceQueryID: "q1", FilePath: filepath.Join(tmpDir, "img1.jpg"), DerivativePaths: map[string]string{"1920x1080": "d1.jpg"}}
 	// img2: Manual/Untagged (should remain)
-	img2 := provider.Image{ID: "img2", SourceQueryID: "", FilePath: filepath.Join(tmpDir, "img2.jpg")}
+	img2 := provider.Image{ID: "img2", SourceQueryID: "", FilePath: filepath.Join(tmpDir, "img2.jpg"), DerivativePaths: map[string]string{"1920x1080": "d2.jpg"}}
 
 	assert.NoError(t, os.WriteFile(img1.FilePath, []byte("1"), 0644))
 	assert.NoError(t, os.WriteFile(img2.FilePath, []byte("2"), 0644))
@@ -91,10 +91,10 @@ func TestStrictSync_MixedState(t *testing.T) {
 	// 3. qA (Active, but file missing) -> Delete (Validation logic)
 	// 4. Untagged -> Keep
 
-	img1 := provider.Image{ID: "img1", SourceQueryID: "qA", FilePath: filepath.Join(tmpDir, "img1.jpg")}
-	img2 := provider.Image{ID: "img2", SourceQueryID: "qB", FilePath: filepath.Join(tmpDir, "img2.jpg")}
-	img3 := provider.Image{ID: "img3", SourceQueryID: "qA", FilePath: filepath.Join(tmpDir, "img3.jpg")}
-	img4 := provider.Image{ID: "img4", SourceQueryID: "", FilePath: filepath.Join(tmpDir, "img4.jpg")}
+	img1 := provider.Image{ID: "img1", SourceQueryID: "qA", FilePath: filepath.Join(tmpDir, "img1.jpg"), DerivativePaths: map[string]string{"1920x1080": "d1.jpg"}}
+	img2 := provider.Image{ID: "img2", SourceQueryID: "qB", FilePath: filepath.Join(tmpDir, "img2.jpg"), DerivativePaths: map[string]string{"1920x1080": "d2.jpg"}}
+	img3 := provider.Image{ID: "img3", SourceQueryID: "qA", FilePath: filepath.Join(tmpDir, "img3.jpg"), DerivativePaths: map[string]string{"1920x1080": "d3.jpg"}}
+	img4 := provider.Image{ID: "img4", SourceQueryID: "", FilePath: filepath.Join(tmpDir, "img4.jpg"), DerivativePaths: map[string]string{"1920x1080": "d4.jpg"}}
 
 	// Create files for 1, 2, 4. Skip 3.
 	assert.NoError(t, os.WriteFile(img1.FilePath, []byte("1"), 0644))

--- a/pkg/wallpaper/store_test.go
+++ b/pkg/wallpaper/store_test.go
@@ -1,6 +1,7 @@
 package wallpaper
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,8 +144,8 @@ func TestStoreSync_Validation(t *testing.T) {
 	// img1: Master Exists.
 	// img2: Master Missing.
 
-	img1 := provider.Image{ID: "img1", Path: "http://url/1.jpg"} // Master -> 1.jpg
-	img2 := provider.Image{ID: "img2", Path: "http://url/2.png"} // Master -> 2.png
+	img1 := provider.Image{ID: "img1", Path: "http://url/1.jpg", DerivativePaths: map[string]string{"1920x1080": "d1.jpg"}} // Master -> 1.jpg
+	img2 := provider.Image{ID: "img2", Path: "http://url/2.png", DerivativePaths: map[string]string{"1920x1080": "d2.jpg"}} // Master -> 2.png
 
 	// Create Master file for img1
 	master1, _ := fm.GetMasterPath("img1", ".jpg")
@@ -185,7 +186,7 @@ func TestStoreSync_Grooming(t *testing.T) {
 		assert.NoError(t, err)
 		err = os.WriteFile(master, []byte(id), 0644)
 		assert.NoError(t, err)
-		store.Add(provider.Image{ID: id, Path: "http://url/" + id + ".jpg"})
+		store.Add(provider.Image{ID: id, Path: "http://url/" + id + ".jpg", DerivativePaths: map[string]string{"1920x1080": id + "_d.jpg"}})
 	}
 
 	// Sync with Limit 2
@@ -220,6 +221,7 @@ func TestStoreSync_CacheInvalidation(t *testing.T) {
 	img1 := provider.Image{
 		ID:              "img1",
 		ProcessingFlags: map[string]bool{"SmartFit": true},
+		DerivativePaths: map[string]string{"1920x1080": "d1.jpg"},
 	}
 	// Create master so it survives validation check
 	master1, _ := fm.GetMasterPath("img1", ".jpg")
@@ -372,16 +374,16 @@ func TestStoreSync_StrictPruning(t *testing.T) {
 	store.SetFileManager(fm, cacheFile)
 
 	// img1: Active Query "qA"
-	img1 := provider.Image{ID: "img1", SourceQueryID: "qA", FilePath: filepath.Join(tmpDir, "img1.jpg")}
+	img1 := provider.Image{ID: "img1", SourceQueryID: "qA", FilePath: filepath.Join(tmpDir, "img1.jpg"), DerivativePaths: map[string]string{"1920x1080": "d1.jpg"}}
 	// img2: Inactive Query "qB"
-	img2 := provider.Image{ID: "img2", SourceQueryID: "qB", FilePath: filepath.Join(tmpDir, "img2.jpg")}
+	img2 := provider.Image{ID: "img2", SourceQueryID: "qB", FilePath: filepath.Join(tmpDir, "img2.jpg"), DerivativePaths: map[string]string{"1920x1080": "d2.jpg"}}
 	// img3: No Query ID (Manual/Legacy) -> Should be kept?
 	// Logic says: if SourceQueryID != "" && !active...
 	// So empty SourceQueryID should correspond to "no active filter apply"?
 	// Or should we delete orphans?
 	// Code: if img.SourceQueryID != "" && !activeQueryIDs[img.SourceQueryID]
 	// So img3 (empty ID) is SAFE.
-	img3 := provider.Image{ID: "img3", SourceQueryID: "", FilePath: filepath.Join(tmpDir, "img3.jpg")}
+	img3 := provider.Image{ID: "img3", SourceQueryID: "", FilePath: filepath.Join(tmpDir, "img3.jpg"), DerivativePaths: map[string]string{"1920x1080": "d3.jpg"}}
 
 	// Create dummy files
 	assert.NoError(t, os.WriteFile(img1.FilePath, []byte("1"), 0644))
@@ -743,7 +745,18 @@ func TestNightlyGroomingSimulation(t *testing.T) {
 	// Expected: Oldest images pruned to fit within cache limit.
 	// =========================================================================
 	t.Run("CacheLimit_PrunesOldest", func(t *testing.T) {
-		// Currently 4 images remain. Sync with limit 2 should prune the 2 oldest.
+		// After ModeChange_InvalidatesAll, all images have empty DerivativePaths.
+		// The zombie recovery logic would delete them. Restore derivatives so
+		// we actually test the cache limit pruning path.
+		for i, img := range store.List() {
+			img.DerivativePaths = map[string]string{
+				"3440x1440": filepath.Join(tmpDir, "fitted", fmt.Sprintf("img%d_3440x1440.jpg", i)),
+			}
+			store.Update(img)
+		}
+		assert.Equal(t, 4, store.Count(), "All 4 images should still be present before pruning")
+
+		// Now Sync with limit 2 should prune the 2 oldest.
 		store.Sync(2, nil, nil)
 		assert.Equal(t, 2, store.Count(), "Should prune down to cache limit of 2")
 	})
@@ -998,10 +1011,10 @@ func TestBlocklist_SyncPrunesBlockedImages(t *testing.T) {
 	store.SetAsyncSave(false)
 	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
 
-	// Add images first
-	img1 := provider.Image{ID: "good_img", SourceQueryID: "q1"}
-	img2 := provider.Image{ID: "bad_img", SourceQueryID: "q1"}
-	img3 := provider.Image{ID: "also_good", SourceQueryID: "q1"}
+	// Add images with DerivativePaths (required to avoid zombie recovery deletion)
+	img1 := provider.Image{ID: "good_img", SourceQueryID: "q1", DerivativePaths: map[string]string{"1920x1080": "good.jpg"}}
+	img2 := provider.Image{ID: "bad_img", SourceQueryID: "q1", DerivativePaths: map[string]string{"1920x1080": "bad.jpg"}}
+	img3 := provider.Image{ID: "also_good", SourceQueryID: "q1", DerivativePaths: map[string]string{"1920x1080": "also.jpg"}}
 
 	createMasterFile(t, fm, "good_img")
 	createMasterFile(t, fm, "bad_img")
@@ -1159,4 +1172,398 @@ func TestBlocklist_ResolutionBucketsAfterSyncPrune(t *testing.T) {
 
 	ids := store.GetIDsForResolution("3440x1440")
 	assert.Equal(t, "clean_img", ids[0])
+}
+
+// =============================================================================
+// Zombie Image Recovery Integration Tests
+// =============================================================================
+//
+// Context: The "flagsMatch length comparison" bug caused nightly grooming to
+// invalidate ALL images. Invalidation wipes DerivativePaths and resets
+// ProcessingFlags. After multiple nights, the store was full of "zombie" images:
+//   - Master files exist on disk
+//   - ProcessingFlags match the target (set correctly during invalidation)
+//   - DerivativePaths is empty → invisible to monitors (no resolution buckets)
+//   - store.Exists(id) returns true → blocks re-fetching
+//
+// The zombie recovery in determineSyncAction detects and deletes these images
+// so they can be re-downloaded and reprocessed.
+// =============================================================================
+
+// newZombieTestStore creates a fresh ImageStore with a FileManager rooted in tmpDir.
+func newZombieTestStore(t *testing.T, tmpDir string) (*ImageStore, *FileManager) {
+	t.Helper()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+	return store, fm
+}
+
+// defaultTargetFlags returns the standard 5-flag target for testing.
+func defaultTargetFlags() map[string]bool {
+	return map[string]bool{
+		"SmartFit":  true,
+		"FaceCrop":  false,
+		"FaceBoost": false,
+		"Upscale":   false,
+		"Fill":      false,
+	}
+}
+
+// newHealthyImage creates an image with master file, correct flags, and derivatives.
+func newHealthyImage(t *testing.T, fm *FileManager, id, queryID, resolution string, flags map[string]bool) provider.Image {
+	t.Helper()
+	createMasterFile(t, fm, id)
+	derivPath := filepath.Join(fm.rootDir, "fitted", id+"_"+resolution+".jpg")
+	return provider.Image{
+		ID:              id,
+		SourceQueryID:   queryID,
+		ProcessingFlags: copyFlags(flags),
+		DerivativePaths: map[string]string{resolution: derivPath},
+	}
+}
+
+// newZombieImage creates an image with master file and correct flags but empty derivatives.
+func newZombieImage(t *testing.T, fm *FileManager, id, queryID string, flags map[string]bool) provider.Image {
+	t.Helper()
+	createMasterFile(t, fm, id)
+	return provider.Image{
+		ID:              id,
+		SourceQueryID:   queryID,
+		ProcessingFlags: copyFlags(flags),
+		DerivativePaths: map[string]string{},
+	}
+}
+
+func TestZombieRecovery_BasicDetection(t *testing.T) {
+	// Zombie with empty DerivativePaths map is detected and deleted.
+	// Healthy image with derivatives survives.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newHealthyImage(t, fm, "healthy", "q1", "3440x1440", flags))
+	store.Add(newZombieImage(t, fm, "zombie", "q1", flags))
+	assert.Equal(t, 2, store.Count())
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count())
+	known := store.GetKnownIDs()
+	assert.True(t, known["healthy"])
+	assert.False(t, known["zombie"])
+}
+
+func TestZombieRecovery_NilDerivativePaths(t *testing.T) {
+	// Some corrupted images may have nil DerivativePaths (not just empty map).
+	// This must also trigger zombie cleanup.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	createMasterFile(t, fm, "nil_deriv")
+	nilImg := provider.Image{
+		ID:              "nil_deriv",
+		SourceQueryID:   "q1",
+		ProcessingFlags: copyFlags(flags),
+		DerivativePaths: nil, // nil, not empty map
+	}
+	store.Add(nilImg)
+	store.Add(newHealthyImage(t, fm, "ok", "q1", "1920x1080", flags))
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count())
+	known := store.GetKnownIDs()
+	assert.False(t, known["nil_deriv"], "nil DerivativePaths should be treated as zombie")
+	assert.True(t, known["ok"])
+}
+
+func TestZombieRecovery_PartialDerivativesNotZombie(t *testing.T) {
+	// An image that has SOME derivatives (even just one) is NOT a zombie.
+	// Only images with zero derivatives are zombies.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	partialImg := newHealthyImage(t, fm, "partial", "q1", "1920x1080", flags)
+	// Only has 1920x1080 derivative, missing 3440x1440 — but that's fine
+	store.Add(partialImg)
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count(), "Image with partial derivatives should survive")
+}
+
+func TestZombieRecovery_ReAddAfterDeletion(t *testing.T) {
+	// After a zombie is deleted from the store, the same image ID can be
+	// re-added with proper derivatives (simulating a re-fetch by the pipeline).
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newZombieImage(t, fm, "revived", "q1", flags))
+	assert.Equal(t, 1, store.Count())
+	assert.True(t, store.Exists("revived"))
+
+	// Zombie gets cleaned
+	store.Sync(100, flags, nil)
+	assert.Equal(t, 0, store.Count())
+	assert.False(t, store.Exists("revived"))
+
+	// Re-add with proper derivatives (simulates pipeline re-download)
+	revivedImg := newHealthyImage(t, fm, "revived", "q1", "3440x1440", flags)
+	added := store.Add(revivedImg)
+	assert.True(t, added, "Zombie should be re-addable after deletion")
+	assert.Equal(t, 1, store.Count())
+
+	// Survives a second Sync (it's healthy now)
+	store.Sync(100, flags, nil)
+	assert.Equal(t, 1, store.Count(), "Re-added healthy image should survive Sync")
+}
+
+func TestZombieRecovery_MultiQueryZombies(t *testing.T) {
+	// Zombies from different source queries are all detected and cleaned.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newZombieImage(t, fm, "z_wallhaven", "wallhaven_q", flags))
+	store.Add(newZombieImage(t, fm, "z_pexels", "pexels_q", flags))
+	store.Add(newZombieImage(t, fm, "z_wikimedia", "wiki_q", flags))
+	store.Add(newHealthyImage(t, fm, "h_wallhaven", "wallhaven_q", "3440x1440", flags))
+	assert.Equal(t, 4, store.Count())
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count())
+	known := store.GetKnownIDs()
+	assert.True(t, known["h_wallhaven"], "Healthy image survives")
+	assert.False(t, known["z_wallhaven"])
+	assert.False(t, known["z_pexels"])
+	assert.False(t, known["z_wikimedia"])
+}
+
+func TestZombieRecovery_ZombieAndBlocklistInteraction(t *testing.T) {
+	// A zombie that is also in the blocklist should be deleted.
+	// The blocklist check runs before the zombie check, so it's deleted
+	// by the avoidSet path — either way, it's removed.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newZombieImage(t, fm, "blocked_zombie", "q1", flags))
+	store.Add(newHealthyImage(t, fm, "clean", "q1", "1920x1080", flags))
+	store.LoadAvoidSet(map[string]bool{"blocked_zombie": true})
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count())
+	assert.False(t, store.GetKnownIDs()["blocked_zombie"])
+	assert.True(t, store.GetKnownIDs()["clean"])
+}
+
+func TestZombieRecovery_PostInvalidationCycle(t *testing.T) {
+	// Simulates the full corruption lifecycle:
+	// 1. Image starts healthy with correct flags + derivatives
+	// 2. Mode change causes invalidation → derivatives wiped, new flags set
+	// 3. Next Sync: flags match now, but derivatives are empty → zombie → deleted
+	store, fm := newZombieTestStore(t, t.TempDir())
+
+	oldFlags := map[string]bool{
+		"SmartFit": false, "FaceCrop": true, "FaceBoost": true,
+		"Upscale": false, "Fill": false,
+	}
+	newFlags := map[string]bool{
+		"SmartFit": true, "FaceCrop": false, "FaceBoost": false,
+		"Upscale": false, "Fill": false,
+	}
+
+	// Step 1: Image is healthy with old flags
+	img := newHealthyImage(t, fm, "transitioning", "q1", "1920x1080", oldFlags)
+	store.Add(img)
+	assert.Equal(t, 1, store.Count())
+
+	// Step 2: User changes mode — Sync invalidates (flags mismatch)
+	store.Sync(100, newFlags, nil)
+
+	// After invalidation: image should still be in store but with new flags and empty derivatives
+	assert.Equal(t, 1, store.Count(), "Image should survive invalidation")
+	updated, ok := store.Get(0)
+	assert.True(t, ok)
+	assert.Empty(t, updated.DerivativePaths, "Derivatives should be wiped after invalidation")
+	assert.Equal(t, newFlags["SmartFit"], updated.ProcessingFlags["SmartFit"])
+
+	// Step 3: NEXT Sync — flags now match, but no derivatives → zombie → delete
+	store.Sync(100, newFlags, nil)
+	assert.Equal(t, 0, store.Count(), "Post-invalidation zombie should be cleaned on next Sync")
+}
+
+func TestZombieRecovery_MassCorruption(t *testing.T) {
+	// Simulates real-world scenario: ALL images in the store were corrupted
+	// by the nightly grooming bug. Every single one is a zombie.
+	// After recovery, the store should be empty and ready for fresh downloads.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	// Add 20 zombie images (simulating a full cache worth of corrupted images)
+	for i := 0; i < 20; i++ {
+		id := fmt.Sprintf("zombie_%03d", i)
+		store.Add(newZombieImage(t, fm, id, "q1", flags))
+	}
+	assert.Equal(t, 20, store.Count())
+
+	// Run Sync — all should be cleaned
+	store.Sync(100, flags, nil)
+	assert.Equal(t, 0, store.Count(), "All 20 zombies should be deleted")
+
+	// Verify store is completely clean
+	assert.Equal(t, 0, store.SeenCount())
+	assert.Empty(t, store.GetKnownIDs())
+}
+
+func TestZombieRecovery_CacheLimitInteraction(t *testing.T) {
+	// When zombies coexist with healthy images and a cache limit is applied,
+	// zombies are deleted first (by zombie detection), THEN the cache limit
+	// prunes the oldest remaining healthy images.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	// Add 3 healthy images
+	store.Add(newHealthyImage(t, fm, "h1", "q1", "3440x1440", flags))
+	store.Add(newHealthyImage(t, fm, "h2", "q1", "3440x1440", flags))
+	store.Add(newHealthyImage(t, fm, "h3", "q1", "3440x1440", flags))
+	// Add 2 zombies
+	store.Add(newZombieImage(t, fm, "z1", "q1", flags))
+	store.Add(newZombieImage(t, fm, "z2", "q1", flags))
+	assert.Equal(t, 5, store.Count())
+
+	// Sync with cache limit of 2: zombies deleted first, then oldest pruned
+	store.Sync(2, flags, nil)
+
+	assert.Equal(t, 2, store.Count(), "Should have exactly 2 healthy images after limit")
+	known := store.GetKnownIDs()
+	assert.False(t, known["z1"], "Zombie should be gone")
+	assert.False(t, known["z2"], "Zombie should be gone")
+	// h1 is oldest and should be pruned by cache limit
+	assert.False(t, known["h1"], "Oldest healthy image should be pruned")
+	assert.True(t, known["h2"], "h2 should survive")
+	assert.True(t, known["h3"], "h3 (newest) should survive")
+}
+
+func TestZombieRecovery_ResolutionBucketIntegrity(t *testing.T) {
+	// After zombie cleanup, resolution buckets must be rebuilt correctly.
+	// Only healthy images should appear in buckets.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newHealthyImage(t, fm, "h_4k", "q1", "3840x2160", flags))
+	store.Add(newHealthyImage(t, fm, "h_uw", "q1", "3440x1440", flags))
+	store.Add(newZombieImage(t, fm, "z1", "q1", flags))
+	store.Add(newZombieImage(t, fm, "z2", "q1", flags))
+
+	assert.Equal(t, 4, store.Count())
+	assert.Equal(t, 1, store.GetBucketSize("3840x2160"))
+	assert.Equal(t, 1, store.GetBucketSize("3440x1440"))
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 2, store.Count())
+	assert.Equal(t, 1, store.GetBucketSize("3840x2160"), "4K bucket should have h_4k")
+	assert.Equal(t, 1, store.GetBucketSize("3440x1440"), "UW bucket should have h_uw")
+
+	// Verify the correct IDs are in each bucket
+	ids4k := store.GetIDsForResolution("3840x2160")
+	assert.Contains(t, ids4k, "h_4k")
+	idsUW := store.GetIDsForResolution("3440x1440")
+	assert.Contains(t, idsUW, "h_uw")
+}
+
+func TestZombieRecovery_WithQueryFilter(t *testing.T) {
+	// When Sync is called with activeQueryIDs (strict mode), zombies from
+	// active queries are cleaned by zombie detection. Zombies from inactive
+	// queries are cleaned by the query filter (ImageActionDelete).
+	// Both paths result in deletion — test that nothing leaks.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newZombieImage(t, fm, "z_active", "active_q", flags))
+	store.Add(newZombieImage(t, fm, "z_inactive", "dead_q", flags))
+	store.Add(newHealthyImage(t, fm, "h_active", "active_q", "1920x1080", flags))
+
+	activeQueries := map[string]bool{"active_q": true}
+	store.Sync(100, flags, activeQueries)
+
+	assert.Equal(t, 1, store.Count())
+	known := store.GetKnownIDs()
+	assert.True(t, known["h_active"], "Healthy image from active query survives")
+	assert.False(t, known["z_active"], "Zombie from active query deleted by zombie check")
+	assert.False(t, known["z_inactive"], "Zombie from inactive query deleted by query filter")
+}
+
+func TestZombieRecovery_NoFalsePositivesWithFlags(t *testing.T) {
+	// When Sync is called with empty/nil targetFlags, the zombie check
+	// should still work (it's independent of flag matching).
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	store.Add(newZombieImage(t, fm, "z1", "q1", flags))
+	store.Add(newHealthyImage(t, fm, "h1", "q1", "1920x1080", flags))
+
+	// Sync with nil targetFlags (like a basic cache-limit-only sync)
+	store.Sync(100, nil, nil)
+
+	assert.Equal(t, 1, store.Count())
+	assert.True(t, store.GetKnownIDs()["h1"])
+	assert.False(t, store.GetKnownIDs()["z1"])
+}
+
+func TestZombieRecovery_PersistenceAcrossRestart(t *testing.T) {
+	// Simulates app restart: store is loaded from cache.json containing
+	// zombie images. After loading + Sync, zombies are cleaned.
+	tmpDir := t.TempDir()
+	store1, fm := newZombieTestStore(t, tmpDir)
+	flags := defaultTargetFlags()
+
+	// Session 1: Add zombie + healthy, save to disk
+	store1.Add(newZombieImage(t, fm, "z_persist", "q1", flags))
+	store1.Add(newHealthyImage(t, fm, "h_persist", "q1", "1920x1080", flags))
+	store1.SaveCache()
+
+	// Session 2: New store, load from cache
+	store2, _ := newZombieTestStore(t, tmpDir)
+	store2.LoadCache()
+	assert.Equal(t, 2, store2.Count(), "Both images should be loaded from cache")
+
+	// Sync detects and cleans zombie
+	store2.Sync(100, flags, nil)
+	assert.Equal(t, 1, store2.Count())
+	assert.True(t, store2.GetKnownIDs()["h_persist"])
+	assert.False(t, store2.GetKnownIDs()["z_persist"], "Zombie should be cleaned after restart")
+}
+
+func TestZombieRecovery_SeenCountReset(t *testing.T) {
+	// Zombies that were previously marked as "seen" should have their
+	// seen count contribution removed when they're deleted.
+	store, fm := newZombieTestStore(t, t.TempDir())
+	flags := defaultTargetFlags()
+
+	// Create zombie with a FilePath (MarkSeen uses filePath, not ID)
+	zImg := newZombieImage(t, fm, "z_seen", "q1", flags)
+	zImg.FilePath = "/fake/z_seen.jpg"
+	store.Add(zImg)
+	store.Add(newHealthyImage(t, fm, "h_unseen", "q1", "1920x1080", flags))
+
+	// Mark zombie as seen using its FilePath
+	store.MarkSeen(zImg.FilePath)
+	assert.Equal(t, 1, store.SeenCount(), "One image should be marked seen")
+
+	// Sync cleans zombie
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count())
+	assert.Equal(t, 0, store.SeenCount(), "Seen count should drop when zombie is deleted")
+}
+
+func copyFlags(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/pkg/wallpaper/store_test.go
+++ b/pkg/wallpaper/store_test.go
@@ -247,6 +247,59 @@ func TestStoreSync_CacheInvalidation(t *testing.T) {
 	}
 }
 
+func TestStoreSync_IncompatibleTagsPreserved(t *testing.T) {
+	// Regression test: flagsMatch must ignore "incompatible:<WxH>" metadata tags.
+	// Images get incompatibility tags added during processing (e.g. "incompatible:1920x1080").
+	// These are NOT processing mode flags and must not cause spurious invalidation.
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, cacheFile)
+
+	// Full processing flags as set by downloader.go, PLUS an incompatibility tag
+	imgFlags := map[string]bool{
+		"SmartFit":               true,
+		"FitFlexibility":         false,
+		"FitQuality":             true,
+		"FaceCrop":               false,
+		"FaceBoost":              false,
+		"incompatible:1920x1080": true, // metadata tag from rejection tagging
+	}
+
+	img1 := provider.Image{
+		ID:              "img1",
+		ProcessingFlags: imgFlags,
+		DerivativePaths: map[string]string{"3440x1440": "/path/to/derivative.jpg"},
+	}
+	// Create master so it survives validation check
+	master1, _ := fm.GetMasterPath("img1", ".jpg")
+	err := os.MkdirAll(filepath.Dir(master1), 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(master1, []byte("fake"), 0644)
+	assert.NoError(t, err)
+
+	store.Add(img1)
+
+	// Target flags match the 5 processing-mode keys exactly
+	targetFlags := map[string]bool{
+		"SmartFit":       true,
+		"FitFlexibility": false,
+		"FitQuality":     true,
+		"FaceCrop":       false,
+		"FaceBoost":      false,
+	}
+	store.Sync(100, targetFlags, nil)
+
+	// Image should be KEPT (not invalidated), because the processing flags match.
+	// The "incompatible:1920x1080" tag should be ignored by flagsMatch.
+	assert.Equal(t, 1, store.Count())
+	got, _ := store.Get(0)
+	assert.NotEmpty(t, got.DerivativePaths, "DerivativePaths should be preserved when flags match")
+	assert.Equal(t, "/path/to/derivative.jpg", got.DerivativePaths["3440x1440"])
+}
+
 func TestGetKnownIDs(t *testing.T) {
 	store := NewImageStore()
 	store.SetAsyncSave(false)
@@ -451,4 +504,659 @@ func TestStore_ResolutionBuckets(t *testing.T) {
 	assert.Equal(t, 1, store.GetBucketSize("1920x1080"))
 	ids = store.GetIDsForResolution("1920x1080")
 	assert.Equal(t, "img2", ids[0])
+}
+
+// =============================================================================
+// Nightly Grooming Simulation
+// =============================================================================
+//
+// This test simulates the full nightly grooming cycle as invoked by scheduler.go.
+// It uses the EXACT flag maps set by downloader.go (ProcessImageJob) and
+// syncStoreWithConfig() to catch any drift between the two.
+//
+// If you add a new processing flag in downloader.go, you MUST update both
+// makeDownloaderFlags() and makeGroomingTarget() below, or this test will
+// fail and tell you exactly what's wrong.
+
+// makeDownloaderFlags builds the ProcessingFlags map exactly as downloader.go does.
+// See downloader.go:L113-126.
+func makeDownloaderFlags(smartFit bool, mode SmartFitMode, faceCrop, faceBoost bool) map[string]bool {
+	return map[string]bool{
+		"SmartFit":       smartFit,
+		"FitFlexibility": mode == SmartFitAggressive,
+		"FitQuality":     mode == SmartFitNormal,
+		"FaceCrop":       faceCrop,
+		"FaceBoost":      faceBoost,
+	}
+}
+
+// makeGroomingTarget builds the targetFlags map exactly as syncStoreWithConfig() does.
+// See wallpaper.go:L1242-1248.
+func makeGroomingTarget(smartFit bool, mode SmartFitMode, faceCrop, faceBoost bool) map[string]bool {
+	return map[string]bool{
+		"SmartFit":       smartFit,
+		"FitFlexibility": mode == SmartFitAggressive,
+		"FitQuality":     mode == SmartFitNormal,
+		"FaceCrop":       faceCrop,
+		"FaceBoost":      faceBoost,
+	}
+}
+
+// createMasterFile creates a fake master .jpg for an image ID so it passes validation.
+func createMasterFile(t *testing.T, fm *FileManager, id string) {
+	t.Helper()
+	master, _ := fm.GetMasterPath(id, ".jpg")
+	err := os.MkdirAll(filepath.Dir(master), 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(master, []byte("fake-"+id), 0644)
+	assert.NoError(t, err)
+}
+
+func TestNightlyGroomingSimulation(t *testing.T) {
+	// -------------------------------------------------------------------------
+	// Setup: Simulate a store with images as they would exist after a day of
+	// normal operation. Images have the full flag set from downloader.go,
+	// some have incompatible tags, some are from different queries.
+	// -------------------------------------------------------------------------
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, cacheFile)
+
+	// Current user config: SmartFit=true, Aggressive mode, FaceCrop=false, FaceBoost=false
+	currentMode := SmartFitAggressive
+	currentSmartFit := true
+	currentFaceCrop := false
+	currentFaceBoost := false
+
+	baseFlags := makeDownloaderFlags(currentSmartFit, currentMode, currentFaceCrop, currentFaceBoost)
+
+	// --- Image 1: Normal image, single monitor, no incompatible tags ---
+	img1Flags := make(map[string]bool)
+	for k, v := range baseFlags {
+		img1Flags[k] = v
+	}
+	img1 := provider.Image{
+		ID:              "MetMuseum_12345",
+		SourceQueryID:   "qA",
+		ProcessingFlags: img1Flags,
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "MetMuseum_12345_3440x1440.jpg")},
+	}
+	createMasterFile(t, fm, img1.ID)
+
+	// --- Image 2: Multi-monitor image, incompatible with secondary monitor ---
+	img2Flags := make(map[string]bool)
+	for k, v := range baseFlags {
+		img2Flags[k] = v
+	}
+	img2Flags["incompatible:1920x1080"] = true // too small for secondary
+	img2 := provider.Image{
+		ID:              "Rijks_67890",
+		SourceQueryID:   "qA",
+		ProcessingFlags: img2Flags,
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "Rijks_67890_3440x1440.jpg")},
+	}
+	createMasterFile(t, fm, img2.ID)
+
+	// --- Image 3: Multi-monitor image, incompatible with TWO monitors ---
+	img3Flags := make(map[string]bool)
+	for k, v := range baseFlags {
+		img3Flags[k] = v
+	}
+	img3Flags["incompatible:1920x1080"] = true
+	img3Flags["incompatible:2560x1440"] = true
+	img3 := provider.Image{
+		ID:              "Cleveland_11111",
+		SourceQueryID:   "qA",
+		ProcessingFlags: img3Flags,
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "Cleveland_11111_3440x1440.jpg")},
+	}
+	createMasterFile(t, fm, img3.ID)
+
+	// --- Image 4: From a DIFFERENT active query ---
+	img4Flags := make(map[string]bool)
+	for k, v := range baseFlags {
+		img4Flags[k] = v
+	}
+	img4 := provider.Image{
+		ID:              "Artic_22222",
+		SourceQueryID:   "qB",
+		ProcessingFlags: img4Flags,
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "Artic_22222_3440x1440.jpg")},
+	}
+	createMasterFile(t, fm, img4.ID)
+
+	// --- Image 5: From an INACTIVE query (should be pruned) ---
+	img5Flags := make(map[string]bool)
+	for k, v := range baseFlags {
+		img5Flags[k] = v
+	}
+	img5 := provider.Image{
+		ID:              "Pexels_33333",
+		SourceQueryID:   "qDEAD",
+		ProcessingFlags: img5Flags,
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "Pexels_33333_3440x1440.jpg")},
+	}
+	createMasterFile(t, fm, img5.ID)
+
+	// --- Image 6: Missing master file (should be pruned) ---
+	img6Flags := make(map[string]bool)
+	for k, v := range baseFlags {
+		img6Flags[k] = v
+	}
+	img6 := provider.Image{
+		ID:              "Wikimedia_44444",
+		SourceQueryID:   "qA",
+		ProcessingFlags: img6Flags,
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "Wikimedia_44444_3440x1440.jpg")},
+	}
+	// NOTE: No createMasterFile for img6 — simulates corrupted/missing master
+
+	store.Add(img1)
+	store.Add(img2)
+	store.Add(img3)
+	store.Add(img4)
+	store.Add(img5)
+	store.Add(img6)
+	assert.Equal(t, 6, store.Count())
+
+	// =========================================================================
+	// Test 1: Steady-State Grooming (same config, no mode change)
+	// Expected: img5 deleted (inactive query), img6 deleted (missing master),
+	//           img1-img4 kept with ALL derivatives and incompatible tags intact.
+	// =========================================================================
+	t.Run("SteadyState_NoModeChange", func(t *testing.T) {
+		target := makeGroomingTarget(currentSmartFit, currentMode, currentFaceCrop, currentFaceBoost)
+		activeQueries := map[string]bool{"qA": true, "qB": true}
+
+		store.Sync(100, target, activeQueries)
+
+		// 4 images should remain
+		assert.Equal(t, 4, store.Count(), "Expected 4 images after steady-state grooming")
+
+		known := store.GetKnownIDs()
+		assert.True(t, known["MetMuseum_12345"], "img1 should survive")
+		assert.True(t, known["Rijks_67890"], "img2 should survive")
+		assert.True(t, known["Cleveland_11111"], "img3 should survive")
+		assert.True(t, known["Artic_22222"], "img4 should survive")
+		assert.False(t, known["Pexels_33333"], "img5 (inactive query) should be deleted")
+		assert.False(t, known["Wikimedia_44444"], "img6 (missing master) should be deleted")
+
+		// Verify derivatives are PRESERVED (not nuked)
+		got1, _ := store.GetByID("MetMuseum_12345")
+		assert.NotEmpty(t, got1.DerivativePaths, "img1 derivatives should be preserved")
+
+		got2, _ := store.GetByID("Rijks_67890")
+		assert.NotEmpty(t, got2.DerivativePaths, "img2 derivatives should be preserved")
+		assert.True(t, got2.ProcessingFlags["incompatible:1920x1080"], "img2 incompatible tag should be preserved")
+
+		got3, _ := store.GetByID("Cleveland_11111")
+		assert.NotEmpty(t, got3.DerivativePaths, "img3 derivatives should be preserved")
+		assert.True(t, got3.ProcessingFlags["incompatible:1920x1080"], "img3 first incompatible tag preserved")
+		assert.True(t, got3.ProcessingFlags["incompatible:2560x1440"], "img3 second incompatible tag preserved")
+
+		// Verify resolution buckets are intact
+		bucketSize := store.GetBucketSize("3440x1440")
+		assert.Equal(t, 4, bucketSize, "All 4 surviving images should be in the 3440x1440 bucket")
+	})
+
+	// =========================================================================
+	// Test 2: Mode Change Grooming (user switches from Aggressive → Normal)
+	// Expected: All remaining images invalidated (derivatives wiped,
+	//           incompatible tags wiped, new flags set). Master files preserved.
+	// =========================================================================
+	t.Run("ModeChange_InvalidatesAll", func(t *testing.T) {
+		newMode := SmartFitNormal // User changed mode
+		target := makeGroomingTarget(currentSmartFit, newMode, currentFaceCrop, currentFaceBoost)
+		// No query filter this time
+		store.Sync(100, target, nil)
+
+		assert.Equal(t, 4, store.Count(), "All 4 images should remain (invalidated, not deleted)")
+
+		// All images should have wiped derivatives
+		for i := 0; i < store.Count(); i++ {
+			img, ok := store.Get(i)
+			assert.True(t, ok)
+			assert.Empty(t, img.DerivativePaths, "Derivatives should be wiped after mode change for %s", img.ID)
+
+			// Flags should now match the new target (incompatible tags wiped)
+			assert.Equal(t, target["SmartFit"], img.ProcessingFlags["SmartFit"])
+			assert.Equal(t, target["FitFlexibility"], img.ProcessingFlags["FitFlexibility"])
+			assert.Equal(t, target["FitQuality"], img.ProcessingFlags["FitQuality"])
+			assert.Equal(t, target["FaceCrop"], img.ProcessingFlags["FaceCrop"])
+			assert.Equal(t, target["FaceBoost"], img.ProcessingFlags["FaceBoost"])
+
+			// Incompatible tags should be GONE (mode change requires re-evaluation)
+			assert.False(t, img.ProcessingFlags["incompatible:1920x1080"],
+				"incompatible tags should be wiped after mode change for %s", img.ID)
+		}
+
+		// Resolution buckets should be EMPTY (no derivatives)
+		assert.Equal(t, 0, store.GetBucketSize("3440x1440"),
+			"Bucket should be empty after invalidation (derivatives wiped)")
+	})
+
+	// =========================================================================
+	// Test 3: Cache Limit Pruning
+	// Expected: Oldest images pruned to fit within cache limit.
+	// =========================================================================
+	t.Run("CacheLimit_PrunesOldest", func(t *testing.T) {
+		// Currently 4 images remain. Sync with limit 2 should prune the 2 oldest.
+		store.Sync(2, nil, nil)
+		assert.Equal(t, 2, store.Count(), "Should prune down to cache limit of 2")
+	})
+}
+
+// =============================================================================
+// Regression Guard: The 2-Flag Bug
+// =============================================================================
+// This test ensures the exact bug that caused the nightly grooming to nuke all
+// derivatives can never silently recur. It simulates what the OLD scheduler code
+// did (passing a 2-flag target) and asserts that it WOULD cause invalidation.
+// The fix was to use the full 5-flag target from syncStoreWithConfig().
+
+func TestNightlyGrooming_RegressionGuard_IncompleteFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	// Image with full downloader flags (as set in production)
+	fullFlags := makeDownloaderFlags(true, SmartFitAggressive, false, false)
+	img := provider.Image{
+		ID:              "Regression_001",
+		ProcessingFlags: fullFlags,
+		DerivativePaths: map[string]string{"3440x1440": "/path/to/derivative.jpg"},
+	}
+	createMasterFile(t, fm, img.ID)
+	store.Add(img)
+
+	// The CORRECT target (5 flags) — should NOT invalidate
+	correctTarget := makeGroomingTarget(true, SmartFitAggressive, false, false)
+	store.Sync(100, correctTarget, nil)
+
+	got, _ := store.GetByID("Regression_001")
+	assert.NotEmpty(t, got.DerivativePaths,
+		"REGRESSION: correct 5-flag target should NOT invalidate matching images")
+
+	// Reset for next check
+	store.Clear()
+	fullFlags2 := makeDownloaderFlags(true, SmartFitAggressive, false, false)
+	img2 := provider.Image{
+		ID:              "Regression_002",
+		ProcessingFlags: fullFlags2,
+		DerivativePaths: map[string]string{"3440x1440": "/path/to/derivative.jpg"},
+	}
+	createMasterFile(t, fm, img2.ID)
+	store.Add(img2)
+
+	// The BROKEN target (only 2 flags, as the old scheduler.go had).
+	// This SHOULD cause invalidation — the reverse check in flagsMatch will
+	// detect that the image has keys (FitFlexibility, FitQuality, FaceBoost)
+	// not present in the target.
+	brokenTarget := map[string]bool{
+		"SmartFit": true,
+		"FaceCrop": false,
+	}
+	store.Sync(100, brokenTarget, nil)
+
+	got2, _ := store.GetByID("Regression_002")
+	assert.Empty(t, got2.DerivativePaths,
+		"REGRESSION GUARD: incomplete 2-flag target MUST invalidate (this was the original bug)")
+
+	// Verify the image was invalidated with the broken flags, not deleted
+	assert.Equal(t, 1, store.Count(), "Image should be invalidated, not deleted")
+	assert.Equal(t, true, got2.ProcessingFlags["SmartFit"])
+	assert.Equal(t, false, got2.ProcessingFlags["FaceCrop"])
+}
+
+// TestFlagsMatch_DownloaderAndGroomingConsistency is a direct unit test that
+// verifies makeDownloaderFlags and makeGroomingTarget produce identical maps
+// for the same inputs. If a new flag is added to one but not the other, this
+// test will catch it.
+func TestFlagsMatch_DownloaderAndGroomingConsistency(t *testing.T) {
+	modes := []SmartFitMode{SmartFitNormal, SmartFitAggressive}
+	bools := []bool{true, false}
+
+	for _, mode := range modes {
+		for _, sf := range bools {
+			for _, fc := range bools {
+				for _, fb := range bools {
+					dl := makeDownloaderFlags(sf, mode, fc, fb)
+					gr := makeGroomingTarget(sf, mode, fc, fb)
+
+					assert.Equal(t, len(dl), len(gr),
+						"Flag count mismatch for mode=%v sf=%v fc=%v fb=%v", mode, sf, fc, fb)
+
+					for k, v := range dl {
+						assert.Equal(t, v, gr[k],
+							"Flag value mismatch for key=%s mode=%v sf=%v fc=%v fb=%v", k, mode, sf, fc, fb)
+					}
+				}
+			}
+		}
+	}
+}
+
+// =============================================================================
+// Query Removal Tests
+// =============================================================================
+
+func TestRemoveByQueryID_ResolutionBuckets(t *testing.T) {
+	// Verifies that resolution buckets are correctly updated when images
+	// are removed by query ID. This prevents stale bucket entries that
+	// would cause the monitor controller to try setting non-existent wallpapers.
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	img1 := provider.Image{
+		ID:            "q1_img1",
+		SourceQueryID: "q1",
+		DerivativePaths: map[string]string{
+			"3440x1440": filepath.Join(tmpDir, "fitted", "q1_img1_3440x1440.jpg"),
+			"1920x1080": filepath.Join(tmpDir, "fitted", "q1_img1_1920x1080.jpg"),
+		},
+	}
+	img2 := provider.Image{
+		ID:            "q1_img2",
+		SourceQueryID: "q1",
+		DerivativePaths: map[string]string{
+			"3440x1440": filepath.Join(tmpDir, "fitted", "q1_img2_3440x1440.jpg"),
+		},
+	}
+	img3 := provider.Image{
+		ID:            "q2_img1",
+		SourceQueryID: "q2",
+		DerivativePaths: map[string]string{
+			"3440x1440": filepath.Join(tmpDir, "fitted", "q2_img1_3440x1440.jpg"),
+			"1920x1080": filepath.Join(tmpDir, "fitted", "q2_img1_1920x1080.jpg"),
+		},
+	}
+
+	store.Add(img1)
+	store.Add(img2)
+	store.Add(img3)
+
+	// Pre-removal: verify bucket state
+	assert.Equal(t, 3, store.GetBucketSize("3440x1440"))
+	assert.Equal(t, 2, store.GetBucketSize("1920x1080"))
+
+	// Remove query q1
+	store.RemoveByQueryID("q1")
+
+	// Post-removal: buckets should only contain q2's images
+	assert.Equal(t, 1, store.GetBucketSize("3440x1440"), "Only q2_img1 should remain in 3440x1440")
+	assert.Equal(t, 1, store.GetBucketSize("1920x1080"), "Only q2_img1 should remain in 1920x1080")
+
+	ids := store.GetIDsForResolution("3440x1440")
+	assert.Equal(t, 1, len(ids))
+	assert.Equal(t, "q2_img1", ids[0])
+}
+
+func TestRemoveByQueryID_SeenCount(t *testing.T) {
+	// Verifies that seen count is correctly decremented when query images are removed.
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+
+	img1 := provider.Image{ID: "img1", SourceQueryID: "q1", Seen: true}
+	img2 := provider.Image{ID: "img2", SourceQueryID: "q1", Seen: true}
+	img3 := provider.Image{ID: "img3", SourceQueryID: "q2", Seen: false}
+	img4 := provider.Image{ID: "img4", SourceQueryID: "q2", Seen: true}
+
+	store.Add(img1)
+	store.Add(img2)
+	store.Add(img3)
+	store.Add(img4)
+
+	assert.Equal(t, 3, store.SeenCount(), "Pre-removal: 3 seen images")
+
+	// Remove q1 (both seen)
+	store.RemoveByQueryID("q1")
+
+	assert.Equal(t, 2, store.Count(), "2 images should remain")
+	assert.Equal(t, 1, store.SeenCount(), "Only img4 (from q2) should be counted as seen")
+}
+
+func TestRemoveByQueryID_NonExistentQuery(t *testing.T) {
+	// Removing a query that doesn't exist should be a no-op.
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+
+	store.Add(provider.Image{ID: "img1", SourceQueryID: "q1"})
+	store.Add(provider.Image{ID: "img2", SourceQueryID: "q2"})
+
+	store.RemoveByQueryID("q_nonexistent")
+
+	assert.Equal(t, 2, store.Count(), "No images should be removed for non-existent query")
+}
+
+func TestRemoveByQueryID_EmptyQueryID(t *testing.T) {
+	// Images with empty SourceQueryID should NOT be removed when removing
+	// a specific query. They are "orphans" from legacy/manual adds.
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+
+	store.Add(provider.Image{ID: "legacy_img", SourceQueryID: ""})
+	store.Add(provider.Image{ID: "q1_img", SourceQueryID: "q1"})
+
+	store.RemoveByQueryID("q1")
+
+	assert.Equal(t, 1, store.Count())
+	known := store.GetKnownIDs()
+	assert.True(t, known["legacy_img"], "Legacy image with empty query ID should survive")
+	assert.False(t, known["q1_img"], "q1 image should be removed")
+}
+
+// =============================================================================
+// Blocklist (AvoidSet) Tests
+// =============================================================================
+
+func TestBlocklist_RemoveAutoPopulates(t *testing.T) {
+	// Verifies that Remove() automatically adds the image ID to the avoidSet,
+	// preventing the same image from being re-added by future fetches.
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	img := provider.Image{
+		ID: "bad_image",
+		DerivativePaths: map[string]string{
+			"3440x1440": filepath.Join(tmpDir, "fitted", "bad_image_3440x1440.jpg"),
+		},
+	}
+	store.Add(img)
+	assert.Equal(t, 1, store.Count())
+	assert.Equal(t, 1, store.GetBucketSize("3440x1440"))
+
+	// Remove the image (user clicked "Block" / "Never show again")
+	_, ok := store.Remove("bad_image")
+	assert.True(t, ok)
+	assert.Equal(t, 0, store.Count())
+	assert.Equal(t, 0, store.GetBucketSize("3440x1440"), "Bucket should be empty after Remove")
+
+	// Try to re-add the same image (simulates next fetch returning it)
+	added := store.Add(provider.Image{ID: "bad_image"})
+	assert.False(t, added, "Blocked image should be rejected by Add()")
+	assert.Equal(t, 0, store.Count(), "Store should still be empty")
+}
+
+func TestBlocklist_SyncPrunesBlockedImages(t *testing.T) {
+	// Verifies that Sync's determineSyncAction correctly deletes images
+	// that are in the avoidSet. This covers the case where an image was
+	// blocked AFTER being added to the store (e.g., loaded from cache).
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	// Add images first
+	img1 := provider.Image{ID: "good_img", SourceQueryID: "q1"}
+	img2 := provider.Image{ID: "bad_img", SourceQueryID: "q1"}
+	img3 := provider.Image{ID: "also_good", SourceQueryID: "q1"}
+
+	createMasterFile(t, fm, "good_img")
+	createMasterFile(t, fm, "bad_img")
+	createMasterFile(t, fm, "also_good")
+
+	store.Add(img1)
+	store.Add(img2)
+	store.Add(img3)
+
+	// Now load the blocklist (simulates app startup loading persisted blocklist)
+	store.LoadAvoidSet(map[string]bool{
+		"bad_img": true,
+	})
+
+	// Run Sync (as nightly grooming would)
+	store.Sync(100, nil, nil)
+
+	// bad_img should be gone
+	assert.Equal(t, 2, store.Count())
+	known := store.GetKnownIDs()
+	assert.True(t, known["good_img"])
+	assert.True(t, known["also_good"])
+	assert.False(t, known["bad_img"], "Blocked image should be pruned by Sync")
+}
+
+func TestBlocklist_InteractionWithQueryRemoval(t *testing.T) {
+	// Tests the full lifecycle:
+	// 1. Images from query q1 are in the store
+	// 2. User blocks one specific image from q1
+	// 3. Query q1 is removed (user deactivates the query)
+	// 4. Query q1 is re-added (user re-enables the query)
+	// 5. Fetch returns all original images including the blocked one
+	// 6. The blocked image must still be rejected
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	// Phase 1: Add images from query q1
+	store.Add(provider.Image{ID: "q1_a", SourceQueryID: "q1"})
+	store.Add(provider.Image{ID: "q1_b", SourceQueryID: "q1"})
+	store.Add(provider.Image{ID: "q1_blocked", SourceQueryID: "q1"})
+	assert.Equal(t, 3, store.Count())
+
+	// Phase 2: User blocks q1_blocked
+	store.Remove("q1_blocked")
+	assert.Equal(t, 2, store.Count())
+
+	// Phase 3: User deactivates query q1
+	store.RemoveByQueryID("q1")
+	assert.Equal(t, 0, store.Count())
+
+	// Phase 4+5: User re-enables q1, fetch returns all 3 images
+	added1 := store.Add(provider.Image{ID: "q1_a", SourceQueryID: "q1"})
+	added2 := store.Add(provider.Image{ID: "q1_b", SourceQueryID: "q1"})
+	added3 := store.Add(provider.Image{ID: "q1_blocked", SourceQueryID: "q1"})
+
+	// Phase 6: Verify
+	assert.True(t, added1, "q1_a should be re-addable")
+	assert.True(t, added2, "q1_b should be re-addable")
+	assert.False(t, added3, "q1_blocked must remain blocked even after query removal/re-add")
+	assert.Equal(t, 2, store.Count())
+}
+
+func TestBlocklist_SurvivesPersistence(t *testing.T) {
+	// Verifies that the avoidSet survives Clear() but not Wipe(),
+	// and that blocked images are still rejected after store reload.
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+
+	// Store 1: Add images, block one, save
+	store1 := NewImageStore()
+	store1.SetAsyncSave(false)
+	store1.SetFileManager(fm, cacheFile)
+
+	store1.Add(provider.Image{ID: "img_a"})
+	store1.Add(provider.Image{ID: "img_b"})
+	store1.Remove("img_b") // Block img_b
+	store1.SaveCache()
+
+	// Simulate app restart: Create new store, load cache
+	store2 := NewImageStore()
+	store2.SetAsyncSave(false)
+	store2.SetFileManager(fm, cacheFile)
+	err := store2.LoadCache()
+	assert.NoError(t, err)
+
+	// img_b should not be in the loaded store
+	assert.Equal(t, 1, store2.Count())
+	known := store2.GetKnownIDs()
+	assert.True(t, known["img_a"])
+	assert.False(t, known["img_b"])
+
+	// However, blocklist is NOT persisted in cache.json (it's loaded from config).
+	// So after LoadCache, trying to add img_b would succeed unless LoadAvoidSet
+	// is called separately. Let's verify this expected behavior:
+	added := store2.Add(provider.Image{ID: "img_b"})
+	// Without LoadAvoidSet, the blocklist is empty in the new store
+	assert.True(t, added, "Without LoadAvoidSet, blocked image can be re-added (blocklist is config-managed)")
+
+	// Now load the blocklist explicitly (as app startup does)
+	store2.Remove("img_b") // Re-block it
+	store2.LoadAvoidSet(map[string]bool{"img_b": true})
+	store2.Clear() // Clear preserves avoidSet
+
+	addedAgain := store2.Add(provider.Image{ID: "img_b"})
+	assert.False(t, addedAgain, "After LoadAvoidSet + Clear, blocked image should still be rejected")
+}
+
+func TestBlocklist_ResolutionBucketsAfterSyncPrune(t *testing.T) {
+	// Verifies that resolution buckets are correctly updated when Sync
+	// prunes blocked images. This is the nightly grooming scenario where
+	// a blocked image somehow ended up in the store (e.g., race condition
+	// or loaded from stale cache).
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	img1 := provider.Image{
+		ID: "clean_img",
+		DerivativePaths: map[string]string{
+			"3440x1440": filepath.Join(tmpDir, "fitted", "clean_3440x1440.jpg"),
+		},
+	}
+	img2 := provider.Image{
+		ID: "will_be_blocked",
+		DerivativePaths: map[string]string{
+			"3440x1440": filepath.Join(tmpDir, "fitted", "blocked_3440x1440.jpg"),
+			"1920x1080": filepath.Join(tmpDir, "fitted", "blocked_1920x1080.jpg"),
+		},
+	}
+
+	createMasterFile(t, fm, "clean_img")
+	createMasterFile(t, fm, "will_be_blocked")
+
+	store.Add(img1)
+	store.Add(img2)
+
+	assert.Equal(t, 2, store.GetBucketSize("3440x1440"))
+	assert.Equal(t, 1, store.GetBucketSize("1920x1080"))
+
+	// Block the image via avoidSet
+	store.LoadAvoidSet(map[string]bool{"will_be_blocked": true})
+
+	// Sync prunes it
+	store.Sync(100, nil, nil)
+
+	assert.Equal(t, 1, store.Count())
+	assert.Equal(t, 1, store.GetBucketSize("3440x1440"), "Only clean_img in 3440x1440")
+	assert.Equal(t, 0, store.GetBucketSize("1920x1080"), "1920x1080 bucket should be empty")
+
+	ids := store.GetIDsForResolution("3440x1440")
+	assert.Equal(t, "clean_img", ids[0])
 }

--- a/pkg/wallpaper/store_test.go
+++ b/pkg/wallpaper/store_test.go
@@ -1308,6 +1308,11 @@ func TestZombieRecovery_ReAddAfterDeletion(t *testing.T) {
 	assert.Equal(t, 0, store.Count())
 	assert.False(t, store.Exists("revived"))
 
+	// Wait for async DeepDeleteBatch goroutine to finish before re-creating
+	// the master file with the same ID. Without this, the goroutine can race
+	// and delete the newly re-created master file on fast platforms (macOS).
+	time.Sleep(100 * time.Millisecond)
+
 	// Re-add with proper derivatives (simulates pipeline re-download)
 	revivedImg := newHealthyImage(t, fm, "revived", "q1", "3440x1440", flags)
 	added := store.Add(revivedImg)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -404,7 +404,7 @@ func (sa *SpiceApp) CreateSplashScreen(seconds int) {
 			errStr := fmt.Sprintf("%v", r)
 			utilLog.Printf("Recovered from splash screen creation panic: %v", errStr)
 			if strings.Contains(strings.ToLower(errStr), "apiunavailable") || strings.Contains(strings.ToLower(errStr), "wgl") || strings.Contains(strings.ToLower(errStr), "opengl") {
-				ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+				ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 			}
 		}
 	}()
@@ -420,7 +420,7 @@ func (sa *SpiceApp) CreateSplashScreen(seconds int) {
 		splashWindow := drv.CreateSplashWindow()
 		if splashWindow == nil {
 			utilLog.Println("Failed to create splash window (driver returned nil)")
-			ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+			ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 			return
 		}
 
@@ -471,7 +471,7 @@ func (sa *SpiceApp) CreatePreferencesWindow(initialTab string) {
 	// Guard: skip if OpenGL is unavailable (Fyne GLFW would crash process)
 	if !sysinfo.CanCreateWindows() {
 		utilLog.Println("OpenGL unavailable — preferences window cannot be created")
-		ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+		ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 		return
 	}
 
@@ -498,7 +498,7 @@ func (sa *SpiceApp) CreatePreferencesWindow(initialTab string) {
 				errStr := fmt.Sprintf("%v", r)
 				utilLog.Printf("Recovered from preferences window creation panic: %v", errStr)
 				if strings.Contains(strings.ToLower(errStr), "apiunavailable") || strings.Contains(strings.ToLower(errStr), "wgl") || strings.Contains(strings.ToLower(errStr), "opengl") {
-					ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+					ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 				}
 			}
 		}()
@@ -507,7 +507,7 @@ func (sa *SpiceApp) CreatePreferencesWindow(initialTab string) {
 
 	if prefsWindow == nil {
 		utilLog.Println("Preferences window creation failed (returned nil or recovered)")
-		ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+		ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 		return
 	}
 
@@ -518,7 +518,7 @@ func (sa *SpiceApp) CreatePreferencesWindow(initialTab string) {
 		defer func() {
 			if r := recover(); r != nil {
 				utilLog.Printf("Recovered from preferences window setup panic: %v", r)
-				ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+				ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 				// Clean up the broken window reference
 				sa.prefsWindow = nil
 				sa.prefsTabs = nil
@@ -1076,7 +1076,7 @@ func (sa *SpiceApp) CreateAboutSplash() {
 			errStr := fmt.Sprintf("%v", r)
 			utilLog.Printf("ERROR: PANIC in CreateAboutSplash (likely stale GLFW context): %v", errStr)
 			if strings.Contains(strings.ToLower(errStr), "apiunavailable") || strings.Contains(strings.ToLower(errStr), "wgl") || strings.Contains(strings.ToLower(errStr), "opengl") {
-				ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+				ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 			}
 		}
 	}()
@@ -1407,7 +1407,7 @@ func (sa *SpiceApp) ShowAnchorPopup(monitorID int, currentAnchor provider.CropAn
 	// Guard: skip if OpenGL is unavailable.
 	if !sysinfo.CanCreateWindows() {
 		utilLog.Println("OpenGL unavailable — anchor popup cannot be created")
-		ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+		ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 		return
 	}
 
@@ -1423,7 +1423,7 @@ func (sa *SpiceApp) ShowAnchorPopup(monitorID int, currentAnchor provider.CropAn
 				errStr := fmt.Sprintf("%v", r)
 				utilLog.Printf("Recovered from anchor popup window creation panic: %v", errStr)
 				if strings.Contains(strings.ToLower(errStr), "apiunavailable") || strings.Contains(strings.ToLower(errStr), "wgl") || strings.Contains(strings.ToLower(errStr), "opengl") {
-					ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background, but the user interface may be unavailable."))
+					ShowNativeFallbackAlert(i18n.T("Graphics Error"), i18n.T("Spice requires OpenGL 2.0+ or hardware acceleration to show windows. The application will continue to run in the background. Please try rebooting your machine to restore graphics functionality."))
 				}
 			}
 		}()


### PR DESCRIPTION
## Description
Fixes nightly grooming silently destroying all cached wallpapers due to a `flagsMatch()` bug, adds self-healing for already-corrupted stores, and caches the OpenGL probe at startup to eliminate UI lag.

**Root Cause:** `flagsMatch()` compared map lengths to determine equality. Images accumulate `incompatible:<WxH>` metadata tags during processing, inflating `ProcessingFlags` beyond the 5-key target. Every nightly Sync saw a length mismatch → invalidated every image → wiped all `DerivativePaths` → monitors saw empty resolution buckets → no wallpapers displayed.

**Zombie Recovery:** Users who were already affected had stores full of "zombie" images — master files exist, flags match, but `DerivativePaths` is empty. These images were invisible to monitors and blocked re-fetching (`store.Exists()` returned true). Added automatic detection and cleanup so affected users don't need to manually delete their download directory.

**OpenGL Probe:** `sysinfo.CanCreateWindows()` was spawning a subprocess (`spice.exe -probe-gl`) on every window open (preferences, splash, anchor popup, about). Cached the result with `sync.Once` so the probe runs once at startup. Updated the error message to suggest rebooting since the result is now cached for the process lifetime.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

**Automated Tests (28 new tests):**
- 14 nightly grooming tests (`TestNightlyGroomingSimulation`, `TestFlagsMatch_DownloaderAndGroomingConsistency`, `TestRemoveByQueryID_*`, `TestBlocklist_*`)
- 14 zombie recovery integration tests (`TestZombieRecovery_*`) covering:
  - Basic detection (empty map + nil `DerivativePaths`)
  - Partial derivatives NOT treated as zombies (no false positives)
  - Re-add lifecycle after deletion
  - Multi-query zombies across providers
  - Zombie + blocklist interaction
  - Post-invalidation cycle (full corruption lifecycle)
  - Mass corruption recovery (20 zombies)
  - Cache limit interaction
  - Resolution bucket integrity after cleanup
  - Active query filter interaction
  - Nil targetFlags edge case
  - Persistence across app restart (cache.json round-trip)
  - Seen count reset on zombie deletion

**Full Validation:**
- `make win-amd64` — i18n sync ✅, gofmt ✅, golangci-lint ✅, all tests ✅, release binary build ✅
- `make security` — gosec ✅

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
