### PR TITLE
fix: MSIX wallpaper, store build polish, and crop anchor state sync

### DIFF
--- a/config/distribution.go
+++ b/config/distribution.go
@@ -1,0 +1,7 @@
+//go:build !appstore && !msstore
+
+package config
+
+// IsStoreDistribution returns true when the binary is built for
+// an app store (Apple App Store or Microsoft Store).
+func IsStoreDistribution() bool { return false }

--- a/config/distribution_store.go
+++ b/config/distribution_store.go
@@ -1,0 +1,7 @@
+//go:build appstore || msstore
+
+package config
+
+// IsStoreDistribution returns true when the binary is built for
+// an app store (Apple App Store or Microsoft Store).
+func IsStoreDistribution() bool { return true }

--- a/config/distribution_test.go
+++ b/config/distribution_test.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsStoreDistribution_StandardBuild verifies that IsStoreDistribution()
+// returns false when built without appstore or msstore tags.
+// The "true" path is verified by building with:
+//   go build -tags "release msstore" ./cmd/spice
+//   go build -tags "release appstore" ./cmd/spice
+func TestIsStoreDistribution_StandardBuild(t *testing.T) {
+	assert.False(t, IsStoreDistribution(), "Standard build should NOT be a store distribution")
+}

--- a/config/distribution_test.go
+++ b/config/distribution_test.go
@@ -9,8 +9,9 @@ import (
 // TestIsStoreDistribution_StandardBuild verifies that IsStoreDistribution()
 // returns false when built without appstore or msstore tags.
 // The "true" path is verified by building with:
-//   go build -tags "release msstore" ./cmd/spice
-//   go build -tags "release appstore" ./cmd/spice
+//
+//	go build -tags "release msstore" ./cmd/spice
+//	go build -tags "release appstore" ./cmd/spice
 func TestIsStoreDistribution_StandardBuild(t *testing.T) {
 	assert.False(t, IsStoreDistribution(), "Standard build should NOT be a store distribution")
 }

--- a/makefile
+++ b/makefile
@@ -201,8 +201,11 @@ build-msix:
 	pwsh -Command "if (Test-Path dist/msix-staging) { Remove-Item -Recurse -Force dist/msix-staging }"
 	pwsh -Command "New-Item -ItemType Directory -Force -Path dist/msix-staging/Assets"
 	
+	@echo "Building MSIX binary with msstore tag..."
+	set GOOS=windows&& set GOARCH=amd64&& go build -tags "release msstore" -o bin/Spice-msstore.exe -ldflags "-H=windowsgui $(LDFLAGS_COMMON)" ./cmd/spice
+
 	@echo "Copying application and assets..."
-	pwsh -Command "Copy-Item bin/Spice.exe dist/msix-staging/"
+	pwsh -Command "Copy-Item bin/Spice-msstore.exe dist/msix-staging/Spice.exe"
 	pwsh -Command "Copy-Item msix/AppxManifest.xml dist/msix-staging/"
 	pwsh -Command "Copy-Item msix/Assets/* dist/msix-staging/Assets/"
 	

--- a/pkg/wallpaper/anchor_state_test.go
+++ b/pkg/wallpaper/anchor_state_test.go
@@ -1,0 +1,170 @@
+//go:build !linux
+
+package wallpaper
+
+import (
+	"context"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dixieflatline76/Spice/v2/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReprocessWithAnchor_StateSync verifies that after reprocessing with
+// a new crop anchor, mc.State.CurrentImage reflects the updated anchor.
+// This prevents regressions where the anchor popup shows a stale selection.
+func TestReprocessWithAnchor_StateSync(t *testing.T) {
+	// --- Setup temp dirs for FileManager ---
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "wallpaper_downloads")
+	resDir := filepath.Join(rootDir, "fitted", "flexibility", "facecrop", "1920x1080")
+	require.NoError(t, os.MkdirAll(rootDir, 0755))
+	require.NoError(t, os.MkdirAll(resDir, 0755))
+
+	// Write a minimal JPEG as the master (stored in rootDir)
+	masterPath := filepath.Join(rootDir, "test_img.jpg")
+	writeTestJPEG(t, masterPath, 200, 200)
+
+	// Write a derivative so reprocessWithAnchor has something to overwrite
+	derivPath := filepath.Join(resDir, "test_img.jpg")
+	writeTestJPEG(t, derivPath, 1920, 1080)
+
+	// --- Create FileManager ---
+	fm := NewFileManager(rootDir)
+
+	// --- Mock dependencies ---
+	mockStore := new(MockImageStore)
+	mockOS := new(MockOS)
+	mockIP := new(MockImageProcessor)
+	cfg := GetConfig(NewMockPreferences())
+
+	monitor := Monitor{
+		ID:   0,
+		Rect: image.Rect(0, 0, 1920, 1080),
+	}
+
+	mc := NewMonitorController(0, monitor, mockStore, fm, mockOS, cfg, mockIP)
+
+	// Set the current image — initially no crop anchors
+	imgID := "test_img"
+	currentImg := provider.Image{
+		ID:       imgID,
+		FilePath: masterPath,
+		DerivativePaths: map[string]string{
+			"1920x1080": derivPath,
+		},
+	}
+	mc.State.CurrentImage = currentImg
+	mc.State.CurrentID = imgID
+
+	// --- Mock expectations ---
+	mockStore.On("SetCropAnchor", imgID, "1920x1080", provider.AnchorTopCenter).Return(true)
+
+	// FitImage should return a valid image (1x1 is fine for test)
+	dummyResult := image.NewRGBA(image.Rect(0, 0, 1920, 1080))
+	mockIP.On("FitImage", mock.Anything, mock.Anything, 1920, 1080, provider.AnchorTopCenter).Return(dummyResult, nil)
+
+	// SetWallpaper should succeed
+	mockOS.On("SetWallpaper", mock.AnythingOfType("string"), 0).Return(nil)
+	mockStore.On("GetUpdateChannel").Return((<-chan struct{})(nil))
+
+	// --- Execute: send anchor command through the Run loop ---
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go mc.Run(ctx)
+
+	mc.Commands <- CmdAnchorTC // TopCenter = 202
+	time.Sleep(300 * time.Millisecond)
+
+	// --- Assert: CurrentImage must reflect the new anchor ---
+	mc.mu.RLock()
+	resultAnchor := mc.State.CurrentImage.GetAnchor("1920x1080")
+	mc.mu.RUnlock()
+
+	assert.Equal(t, provider.AnchorTopCenter, resultAnchor,
+		"CurrentImage.CropAnchors should reflect the new anchor after reprocessing")
+
+	mockStore.AssertExpectations(t)
+	mockIP.AssertExpectations(t)
+}
+
+// TestReprocessWithAnchor_AnchorAuto_ClearsMap verifies that setting
+// AnchorAuto removes the resolution entry from the CropAnchors map.
+func TestReprocessWithAnchor_AnchorAuto_ClearsMap(t *testing.T) {
+	tmpDir := t.TempDir()
+	rootDir := filepath.Join(tmpDir, "wallpaper_downloads")
+	resDir := filepath.Join(rootDir, "fitted", "flexibility", "facecrop", "1920x1080")
+	require.NoError(t, os.MkdirAll(rootDir, 0755))
+	require.NoError(t, os.MkdirAll(resDir, 0755))
+
+	masterPath := filepath.Join(rootDir, "test_img.jpg")
+	writeTestJPEG(t, masterPath, 200, 200)
+	derivPath := filepath.Join(resDir, "test_img.jpg")
+	writeTestJPEG(t, derivPath, 1920, 1080)
+
+	fm := NewFileManager(rootDir)
+	mockStore := new(MockImageStore)
+	mockOS := new(MockOS)
+	mockIP := new(MockImageProcessor)
+	cfg := GetConfig(NewMockPreferences())
+
+	monitor := Monitor{ID: 0, Rect: image.Rect(0, 0, 1920, 1080)}
+	mc := NewMonitorController(0, monitor, mockStore, fm, mockOS, cfg, mockIP)
+
+	// Start with an existing anchor
+	mc.State.CurrentImage = provider.Image{
+		ID:       "test_img",
+		FilePath: masterPath,
+		CropAnchors: map[string]provider.CropAnchor{
+			"1920x1080": provider.AnchorTopCenter,
+		},
+		DerivativePaths: map[string]string{
+			"1920x1080": derivPath,
+		},
+	}
+	mc.State.CurrentID = "test_img"
+
+	mockStore.On("SetCropAnchor", "test_img", "1920x1080", provider.AnchorAuto).Return(true)
+	dummyResult := image.NewRGBA(image.Rect(0, 0, 1920, 1080))
+	mockIP.On("FitImage", mock.Anything, mock.Anything, 1920, 1080, provider.AnchorAuto).Return(dummyResult, nil)
+	mockOS.On("SetWallpaper", mock.AnythingOfType("string"), 0).Return(nil)
+	mockStore.On("GetUpdateChannel").Return((<-chan struct{})(nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go mc.Run(ctx)
+
+	mc.Commands <- CmdAnchorAuto // Auto = 200
+	time.Sleep(300 * time.Millisecond)
+
+	mc.mu.RLock()
+	_, exists := mc.State.CurrentImage.CropAnchors["1920x1080"]
+	mc.mu.RUnlock()
+
+	assert.False(t, exists, "AnchorAuto should clear the resolution entry from CropAnchors")
+	mockStore.AssertExpectations(t)
+}
+
+// writeTestJPEG creates a minimal JPEG file for testing.
+func writeTestJPEG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	// Fill with a non-transparent color so imaging.Open doesn't fail
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.NRGBA{R: 100, G: 150, B: 200, A: 255})
+		}
+	}
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, jpeg.Encode(f, img, &jpeg.Options{Quality: 50}))
+}

--- a/pkg/wallpaper/deactivate_test.go
+++ b/pkg/wallpaper/deactivate_test.go
@@ -1,0 +1,116 @@
+//go:build !linux
+
+package wallpaper
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dixieflatline76/Spice/v2/config"
+	"github.com/dixieflatline76/Spice/v2/pkg/provider"
+	"github.com/dixieflatline76/Spice/v2/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestDeactivate_SuppressesNotificationDuringShutdown verifies that when
+// Deactivate() is called while a fetch is in progress, the "Downloading X
+// new images..." notification is NOT sent to the user.
+//
+// This is a regression test for the quit-notification race:
+// 1. FetchNewImages starts with a slow provider
+// 2. Deactivate() is called mid-fetch
+// 3. The provider completes and queues images
+// 4. The notification should be suppressed because interrupt is set
+func TestDeactivate_SuppressesNotificationDuringShutdown(t *testing.T) {
+	// Track whether the provider's FetchImages was actually called
+	var fetchStarted atomic.Bool
+
+	// Setup Plugin
+	ctx, cancel := context.WithCancel(context.Background())
+	wp := &Plugin{
+		providers:          make(map[string]provider.ImageProvider),
+		queryPages:         make(map[string]*util.SafeCounter),
+		fetchingInProgress: util.NewSafeBool(),
+		interrupt:          util.NewSafeBool(),
+		store:              &MockImageStore{},
+		ctx:                ctx,
+		cancel:             cancel,
+		queryContexts:      make(map[string]context.Context),
+		queryCancelFuncs:   make(map[string]context.CancelFunc),
+		manager:            &MockPluginManager{},
+		Monitors:           make(map[int]*MonitorController),
+		os:                 &MockOS{},
+	}
+
+	// Mock manager — track NotifyUser calls
+	mockManager := wp.manager.(*MockPluginManager)
+	// We deliberately do NOT set .Maybe() here so we can assert it was NOT called
+	// with the fetch notification title.
+
+	// Mock Store
+	mockStore := wp.store.(*MockImageStore)
+	mockStore.On("GetByID", mock.Anything).Return(provider.Image{}, false)
+
+	// Mock OS
+	wp.os.(*MockOS).On("GetMonitors").Return([]Monitor{}, nil).Maybe()
+
+	// Mock Pipeline — accepts all jobs
+	mockPipeline := &MockPipeline{}
+	wp.jobSubmitter = mockPipeline
+	mockPipeline.On("Submit", mock.Anything, mock.Anything).Return(true)
+
+	// Setup slow provider: takes 300ms to respond (simulates active HTTP call)
+	slowProvider := &MockImageProvider{}
+	slowProvider.On("ID").Return("SlowMuseum").Maybe()
+	slowProvider.On("FetchImages", mock.Anything, "slow-query", 1).
+		Return([]provider.Image{
+			{ID: "img1", Path: "https://example.com/1.jpg"},
+			{ID: "img2", Path: "https://example.com/2.jpg"},
+			{ID: "img3", Path: "https://example.com/3.jpg"},
+		}, nil).
+		Run(func(args mock.Arguments) {
+			fetchStarted.Store(true)
+			time.Sleep(300 * time.Millisecond) // Simulate slow HTTP call
+		}).Once()
+
+	wp.providers["SlowMuseum"] = slowProvider
+
+	// Config with one active query
+	wp.cfg = &Config{
+		Queries: []ImageQuery{
+			{ID: "q1", Provider: "SlowMuseum", Active: true, URL: "slow-query", Description: "Slow"},
+		},
+	}
+
+	// Ensure working dir exists
+	workingDir := config.GetWorkingDir()
+	_ = os.MkdirAll(filepath.Join(workingDir, "wallpaper_downloads"), 0755)
+
+	// --- ACT ---
+
+	// 1. Start fetch (runs in goroutine)
+	wp.FetchNewImages(true)
+
+	// 2. Wait until the provider is actually mid-call
+	assert.Eventually(t, func() bool {
+		return fetchStarted.Load()
+	}, 2*time.Second, 10*time.Millisecond, "Provider FetchImages should have started")
+
+	// 3. Deactivate while fetch is in progress
+	wp.Deactivate()
+
+	// 4. Wait for the fetch goroutine to complete (it will because the
+	//    provider sleep finishes after 300ms)
+	time.Sleep(500 * time.Millisecond)
+
+	// --- ASSERT ---
+
+	// The notification should NOT have been sent because interrupt was set
+	// during Deactivate() before the fetch goroutine reached the notification.
+	mockManager.AssertNotCalled(t, "NotifyUser", "Wallpaper Fetch", mock.Anything)
+}

--- a/pkg/wallpaper/fetch_logic.go
+++ b/pkg/wallpaper/fetch_logic.go
@@ -113,7 +113,7 @@ func (wp *Plugin) FetchNewImages(force bool, providerID ...string) {
 
 			// Batch Reshuffle Optimization (User Approach):
 			// Signal monitors to update their shuffle lists only after the entire batch is processed.
-			if totalQueued.Value() > 0 {
+			if totalQueued.Value() > 0 && (wp.interrupt == nil || !wp.interrupt.Value()) {
 				log.Debugf("[Fetch] Processed %d new images. Broadcasting shuffle update to monitors...", totalQueued.Value())
 				wp.dispatch(-1, CmdUpdateShuffle)
 

--- a/pkg/wallpaper/monitor_controller.go
+++ b/pkg/wallpaper/monitor_controller.go
@@ -536,6 +536,19 @@ func (mc *MonitorController) reprocessWithAnchor(anchor provider.CropAnchor) {
 	resKey := fmt.Sprintf("%dx%d", mc.Monitor.Rect.Dx(), mc.Monitor.Rect.Dy())
 	mc.Store.SetCropAnchor(img.ID, resKey, anchor)
 
+	// Mirror the anchor change into the local image copy so that
+	// mc.State.CurrentImage stays in sync with the store. Without this,
+	// the anchor popup would show the stale (pre-change) anchor until
+	// the user navigates away and back.
+	if img.CropAnchors == nil {
+		img.CropAnchors = make(map[string]provider.CropAnchor)
+	}
+	if anchor == provider.AnchorAuto {
+		delete(img.CropAnchors, resKey)
+	} else {
+		img.CropAnchors[resKey] = anchor
+	}
+
 	// 2. Find master path
 	ext := filepath.Ext(img.FilePath)
 	if ext == "" {

--- a/pkg/wallpaper/msix_other.go
+++ b/pkg/wallpaper/msix_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package wallpaper
+
+// resolveMSIXPath is a no-op on non-Windows platforms.
+// MSIX packaging only exists on Windows.
+func resolveMSIXPath(p string) string { return p }

--- a/pkg/wallpaper/msix_windows.go
+++ b/pkg/wallpaper/msix_windows.go
@@ -1,0 +1,154 @@
+//go:build windows
+// +build windows
+
+package wallpaper
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modKernel32                     = syscall.NewLazyDLL("kernel32.dll")
+	procGetCurrentPackageFamilyName = modKernel32.NewProc("GetCurrentPackageFamilyName")
+)
+
+const (
+	appmodelErrorNoPackage = 15700
+)
+
+// msixPackageFamilyName holds the cached package family name.
+// Empty string means "not running in MSIX" (or detection failed).
+var msixPackageFamilyName string
+
+// msixWallpaperStaging is the directory where wallpapers are copied
+// before being passed to IDesktopWallpaper::SetWallpaper.
+// This ensures explorer.exe can always access the file.
+var msixWallpaperStaging string
+
+func init() {
+	msixPackageFamilyName = detectMSIXFamilyName()
+	if msixPackageFamilyName != "" {
+		// Use %USERPROFILE%\Pictures\SpiceWallpapers as the staging area.
+		// This is always accessible by explorer.exe and not subject to
+		// any MSIX container virtualization.
+		home, err := os.UserHomeDir()
+		if err == nil {
+			msixWallpaperStaging = filepath.Join(home, "Pictures", "SpiceWallpapers")
+			_ = os.MkdirAll(msixWallpaperStaging, 0755)
+		}
+		log.Printf("MSIX: Running in package %s", msixPackageFamilyName)
+		log.Printf("MSIX: Wallpaper staging dir: %s", msixWallpaperStaging)
+	}
+}
+
+// detectMSIXFamilyName calls GetCurrentPackageFamilyName to determine
+// if this process is running inside an MSIX/AppX container. Returns the
+// package family name, or "" if not packaged.
+func detectMSIXFamilyName() string {
+	// First call: get required buffer length
+	var length uint32
+	r, _, _ := procGetCurrentPackageFamilyName.Call(
+		uintptr(unsafe.Pointer(&length)),
+		0, // nil buffer
+	)
+
+	// APPMODEL_ERROR_NO_PACKAGE means we are NOT in an MSIX container
+	if r == appmodelErrorNoPackage {
+		return ""
+	}
+
+	// ERROR_INSUFFICIENT_BUFFER (122) is expected — length now contains the required size
+	if length == 0 {
+		return ""
+	}
+
+	// Second call: retrieve the family name
+	buf := make([]uint16, length)
+	r, _, _ = procGetCurrentPackageFamilyName.Call(
+		uintptr(unsafe.Pointer(&length)),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+	if r != 0 {
+		return ""
+	}
+
+	return syscall.UTF16ToString(buf)
+}
+
+// resolveMSIXPath ensures the wallpaper file is accessible by explorer.exe
+// when running inside an MSIX package.
+//
+// MSIX container boundaries can prevent explorer.exe (which runs outside the
+// container) from accessing files written by the packaged app, even when they
+// appear to exist at a normal path. This function copies the wallpaper to a
+// staging directory in %USERPROFILE%\Pictures that is always accessible.
+func resolveMSIXPath(imagePath string) string {
+	if msixPackageFamilyName == "" || msixWallpaperStaging == "" {
+		return imagePath // Not in MSIX, nothing to do
+	}
+
+	// Verify the source file exists before copying
+	if _, err := os.Stat(imagePath); err != nil {
+		log.Printf("MSIX: Source file does not exist: %s", imagePath)
+		return imagePath
+	}
+
+	// Copy to staging directory, preserving just the filename
+	filename := filepath.Base(imagePath)
+	stagedPath := filepath.Join(msixWallpaperStaging, filename)
+
+	// Skip if already staged and same size
+	srcInfo, _ := os.Stat(imagePath)
+	if dstInfo, err := os.Stat(stagedPath); err == nil {
+		if srcInfo != nil && dstInfo.Size() == srcInfo.Size() {
+			return stagedPath
+		}
+	}
+
+	if err := copyFile(imagePath, stagedPath); err != nil {
+		log.Printf("MSIX: Failed to stage wallpaper %s -> %s: %v", imagePath, stagedPath, err)
+		return imagePath // Fall back to original path
+	}
+
+	return stagedPath
+}
+
+// copyFile copies src to dst atomically using a temp file + rename.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer in.Close()
+
+	// Write to a temp file in the same directory, then rename
+	tmp := dst + ".tmp"
+	out, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+
+	_, err = io.Copy(out, in)
+	closeErr := out.Close()
+	if err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("copy: %w", err)
+	}
+	if closeErr != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("close: %w", closeErr)
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/wallpaper/store_test.go
+++ b/pkg/wallpaper/store_test.go
@@ -1311,7 +1311,7 @@ func TestZombieRecovery_ReAddAfterDeletion(t *testing.T) {
 	// Wait for async DeepDeleteBatch goroutine to finish before re-creating
 	// the master file with the same ID. Without this, the goroutine can race
 	// and delete the newly re-created master file on fast platforms (macOS).
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Re-add with proper derivatives (simulates pipeline re-download)
 	revivedImg := newHealthyImage(t, fm, "revived", "q1", "3440x1440", flags)

--- a/pkg/wallpaper/wallpaper.go
+++ b/pkg/wallpaper/wallpaper.go
@@ -486,6 +486,11 @@ func (wp *Plugin) Activate() {
 func (wp *Plugin) Deactivate() {
 	log.Print("Deactivating wallpaper plugin...")
 
+	// Cancel the fetch context FIRST to abort any in-progress fetch cycle.
+	// This must happen before stopAllWorkers() which blocks waiting for
+	// downloads, giving the fetch goroutine time to send a spurious notification.
+	wp.CancelFetchContext()
+
 	wp.downloadMutex.Lock()
 	if wp.stopNightlyRefresh != nil {
 		close(wp.stopNightlyRefresh)
@@ -509,7 +514,7 @@ func (wp *Plugin) Deactivate() {
 	if wp.pipeline != nil {
 		wp.pipeline.Stop()
 	}
-	wp.CancelFetchContext()
+	// Note: CancelFetchContext() already called at top of Deactivate().
 
 	// Stop Monitors
 	wp.monMu.Lock() // Write lock needed for map modification if we were to delete, but here just stopping

--- a/pkg/wallpaper/windows.go
+++ b/pkg/wallpaper/windows.go
@@ -168,6 +168,10 @@ func (w *windowsOS) getPrimaryMonitorFallback() ([]Monitor, error) {
 // SetWallpaper sets the desktop wallpaper
 // TODO(Stage 6): Use IDesktopWallpaper for per-monitor support (monitorID)
 func (w *windowsOS) SetWallpaper(imagePath string, monitorID int) error {
+	// Resolve MSIX-virtualized path so explorer.exe (outside the container)
+	// can find the file when setting it via IDesktopWallpaper COM API.
+	imagePath = resolveMSIXPath(imagePath)
+
 	imagePathUTF16, err := syscall.UTF16PtrFromString(imagePath)
 	if err != nil {
 		return err

--- a/ui/settings_manager.go
+++ b/ui/settings_manager.go
@@ -425,10 +425,13 @@ func (sm *SettingsManager) renderBoolSetting(cfg *boolConfig, header *fyne.Conta
 		}
 	}
 
+	// Keep a reference to the label row so we can manage its visibility
+	var labelRow fyne.CanvasObject
 	if labelIsEmpty {
 		header.Add(check)
 	} else {
-		header.Add(NewSplitRow(label, check, SplitProportion.OneThird))
+		labelRow = NewSplitRow(label, check, SplitProportion.OneThird)
+		header.Add(labelRow)
 	}
 	if cfg.HelpContent != nil {
 		header.Add(cfg.HelpContent)
@@ -458,13 +461,29 @@ func (sm *SettingsManager) renderBoolSetting(cfg *boolConfig, header *fyne.Conta
 		return check.Checked
 	}
 
-	// Track if it has an EnabledIf or VisibleIf condition
+	// Track if it has an EnabledIf or VisibleIf condition.
+	// When VisibleIf is set, also register the label row and help text
+	// so they are hidden/shown together with the checkbox.
 	if cfg.EnabledIf != nil || cfg.VisibleIf != nil {
 		sm.managedWidgets = append(sm.managedWidgets, managedWidget{
 			widget:    check,
 			enabledIf: cfg.EnabledIf,
 			visibleIf: cfg.VisibleIf,
 		})
+		if cfg.VisibleIf != nil {
+			if labelRow != nil {
+				sm.managedWidgets = append(sm.managedWidgets, managedWidget{
+					widget:    labelRow,
+					visibleIf: cfg.VisibleIf,
+				})
+			}
+			if cfg.HelpContent != nil {
+				sm.managedWidgets = append(sm.managedWidgets, managedWidget{
+					widget:    cfg.HelpContent,
+					visibleIf: cfg.VisibleIf,
+				})
+			}
+		}
 	}
 
 	sm.allWidgets[cfg.Name] = check

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -640,6 +640,7 @@ func (sa *SpiceApp) RebuildPreferencesContent(initialTab string) {
 						ApplyFunc: func(b bool) {
 							sa.appConfig.SetUpdateCheckEnabled(b)
 						},
+						VisibleIf: func() bool { return !config.IsStoreDistribution() },
 					},
 					schema.BoolItem{
 						Name:         "enableShortcuts",
@@ -866,7 +867,9 @@ func (sa *SpiceApp) Start() {
 
 	// Create the tray menu
 	saInstance.CreateTrayMenu()
-	go sa.StartStartupUpdateCheck()
+	if !config.IsStoreDistribution() {
+		go sa.StartStartupUpdateCheck()
+	}
 
 	// Activate all plugins
 	go func() {


### PR DESCRIPTION
**PR Title:** `fix: MSIX wallpaper, store build polish, and crop anchor state sync`

---

## Description

Targeted fixes for v2.5.7 — resolving the Microsoft Store certification blocker, quit race condition, and crop anchor UI bug.

### 1. MSIX Wallpaper `SetWallpaper` Failure (`0x80070002`)

**Root Cause:** MSIX filesystem write virtualization redirects `%LocalAppData%` writes to a private per-package directory. `IDesktopWallpaper::SetWallpaper` passes the file path to `explorer.exe` (outside the container), which cannot access the virtualized path → `ERROR_FILE_NOT_FOUND`.

**Fix:** Detect MSIX context via `GetCurrentPackageFamilyName` and copy wallpaper files to `%USERPROFILE%\Pictures\SpiceWallpapers\` before calling the COM API. This path is never virtualized and always accessible by `explorer.exe`.

- **`pkg/wallpaper/msix_windows.go`** [NEW] — MSIX detection, staging copy with atomic write, file-size dedup
- **`pkg/wallpaper/msix_other.go`** [NEW] — no-op stub for non-Windows
- **`pkg/wallpaper/windows.go`** — call `resolveMSIXPath()` in `SetWallpaper`

### 2. Hide Update Check in Store Builds (VisibleIf fix)

The "Enable New Version Check" preference row was partially visible in store builds — the checkbox was hidden but the **label and help text** remained.

**Fix:** Register the label row and help text as additional managed widgets in `VisibleIf`, so all three elements hide/show together.

- **`ui/settings_manager.go`** — capture label `SplitRow` and help content, register as managed widgets

### 3. Disable GitHub Update Check for Store Builds

Both Apple App Store and Microsoft Store prohibit directing users to external download sources.

**Fix:** `config.IsStoreDistribution()` compile-time flag via build tags (`appstore`, `msstore`). Guards `StartStartupUpdateCheck()` and hides the preference toggle.

### 4. Quit Notification Race Condition

**Root Cause:** `Deactivate()` cancelled the fetch context *after* `stopAllWorkers()`, giving the fetch goroutine time to complete and fire a notification during shutdown.

**Fix:** Move `CancelFetchContext()` to the top of `Deactivate()` and guard the notification with the `wp.interrupt` flag.

### 5. Crop Anchor Popup Showing Stale Selection

**Root Cause:** `reprocessWithAnchor` captured a copy of `CurrentImage` before calling `SetCropAnchor`, then wrote the stale copy back to `mc.State.CurrentImage`. The anchor popup read the old value.

**Fix:** Mirror the anchor change into the local image copy after persisting to the store.

- **`pkg/wallpaper/monitor_controller.go`** — sync `img.CropAnchors` after `SetCropAnchor`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- **MSIX wallpaper:** Full sideload test — `make build-msix-dev`, install, wallpaper changes confirmed working via `IDesktopWallpaper::SetWallpaper` (no more `0x80070002`)
- **VisibleIf:** Screenshot comparison — MSIX build hides entire row, standard exe shows it
- **Quit race:** `TestDeactivate_SuppressesNotificationDuringShutdown`
- **Store distribution:** `TestIsStoreDistribution_StandardBuild`
- **Crop anchor:** `TestReprocessWithAnchor_StateSync`, `TestReprocessWithAnchor_AnchorAuto_ClearsMap`
- **Build verification:** All three variants compile cleanly:
  - `go build ./...` (standard)
  - `go build -tags "release appstore" ./...` (macOS App Store)
  - `go build -tags "release msstore" ./...` (MS Store)
- All existing unit tests pass.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
