### PR TITLE
fix: preserve CropAnchors across settings changes and pipeline replacements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 )
 
 require (
-	fyne.io/systray v1.12.1 // indirect
+	fyne.io/systray v1.12.2 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fyne.io/fyne/v2 v2.7.4 h1:OVCI5mT+Onb2kA4wlmGA5pLCqKik9f4NDb5jiR1OMTc=
 fyne.io/fyne/v2 v2.7.4/go.mod h1:ZD1mmhBY75mSa97IXl3MPlICd1uNHfCXYh5hKIlVOII=
-fyne.io/systray v1.12.1 h1:ygBD6aZXwiOmZoY5N+ukbH9pih0Kq6fYgVeMYbr5skQ=
-fyne.io/systray v1.12.1/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
+fyne.io/systray v1.12.2 h1:Y8DZxgLHsVQt6rY9Zrkkg+j67S7vv/1F2viOWKPpVeA=
+fyne.io/systray v1.12.2/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=

--- a/pkg/wallpaper/crop_anchor_regression_test.go
+++ b/pkg/wallpaper/crop_anchor_regression_test.go
@@ -1,0 +1,410 @@
+package wallpaper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dixieflatline76/Spice/v2/pkg/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// Crop Anchor Persistence — Regression Test Suite
+// =============================================================================
+//
+// These tests guard against the guaranteed-clobber bug where CropAnchors were
+// deterministically destroyed during settings changes (double-Sync pattern)
+// and pipeline replacements.
+//
+// Run with: go test -v -run "TestCropAnchor_" ./pkg/wallpaper
+//
+// If ANY of these tests fail, user-set crop anchors are being silently lost.
+
+// =============================================================================
+// Category 1: Fix Mechanics (Unit-Level)
+// =============================================================================
+
+// TestCropAnchor_Replace_PreservesExisting verifies that replace() with a
+// pipeline result (no CropAnchors) does NOT overwrite existing store anchors.
+// This is the secondary bug: the pipeline never writes CropAnchors, so the
+// store's values must survive a full struct replacement.
+func TestCropAnchor_Replace_PreservesExisting(t *testing.T) {
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+
+	// Step 1: Image enters store with derivatives (normal pipeline completion)
+	initial := provider.Image{
+		ID:              "img1",
+		Width:           4000,
+		Height:          3000,
+		DerivativePaths: map[string]string{"3440x1440": "/path/to/deriv.jpg"},
+		ProcessingFlags: map[string]bool{"SmartFit": true},
+	}
+	store.Add(initial)
+
+	// Step 2: User sets crop anchor via UI
+	store.SetCropAnchor("img1", "3440x1440", provider.AnchorTopCenter)
+
+	// Verify anchor was stored
+	got, _ := store.GetByID("img1")
+	assert.Equal(t, provider.AnchorTopCenter, got.CropAnchors["3440x1440"])
+
+	// Step 3: Pipeline re-processes image (backlog healing) — result has NO CropAnchors
+	pipelineResult := provider.Image{
+		ID:              "img1",
+		Width:           4000,
+		Height:          3000,
+		DerivativePaths: map[string]string{"3440x1440": "/path/to/new_deriv.jpg"},
+		ProcessingFlags: map[string]bool{"SmartFit": true},
+		// CropAnchors: nil — pipeline never sets this
+	}
+	store.replace(pipelineResult)
+
+	// Step 4: Verify anchor survived the replace
+	got, ok := store.GetByID("img1")
+	assert.True(t, ok)
+	assert.Equal(t, provider.AnchorTopCenter, got.CropAnchors["3440x1440"],
+		"CropAnchors must survive replace() — the store is authoritative for user metadata")
+	assert.Equal(t, "/path/to/new_deriv.jpg", got.DerivativePaths["3440x1440"],
+		"DerivativePaths should still be updated by replace")
+}
+
+// TestCropAnchor_Replace_HonorsRemoval verifies that if the user removed all
+// anchors (via AnchorAuto) while the pipeline was processing, replace() does
+// NOT resurrect stale anchors from MergeExistingMetadata.
+func TestCropAnchor_Replace_HonorsRemoval(t *testing.T) {
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+
+	// Step 1: Image with an anchor
+	img := provider.Image{
+		ID:              "img1",
+		DerivativePaths: map[string]string{"3440x1440": "/deriv.jpg"},
+		CropAnchors:     map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter},
+	}
+	store.Add(img)
+
+	// Step 2: User removes the anchor (SetCropAnchor with AnchorAuto deletes the key)
+	store.SetCropAnchor("img1", "3440x1440", provider.AnchorAuto)
+
+	// Verify anchor is gone from store
+	got, _ := store.GetByID("img1")
+	_, exists := got.CropAnchors["3440x1440"]
+	assert.False(t, exists, "Anchor should be removed after AnchorAuto")
+
+	// Step 3: Pipeline result arrives with stale anchor from MergeExistingMetadata
+	// (this happens when MergeExistingMetadata ran before the user cleared the anchor)
+	pipelineResult := provider.Image{
+		ID:              "img1",
+		DerivativePaths: map[string]string{"3440x1440": "/new_deriv.jpg"},
+		CropAnchors:     map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter}, // stale!
+	}
+	store.replace(pipelineResult)
+
+	// Step 4: The store's empty state must win — anchor must NOT be resurrected
+	got, _ = store.GetByID("img1")
+	assert.Nil(t, got.CropAnchors,
+		"replace() must NOT resurrect anchors the user explicitly removed")
+}
+
+// TestCropAnchor_Replace_MidFlight verifies that if the user changes an anchor
+// WHILE the pipeline is processing, the user's newer choice wins.
+func TestCropAnchor_Replace_MidFlight(t *testing.T) {
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+
+	// Step 1: Image with initial anchor
+	img := provider.Image{
+		ID:              "img1",
+		DerivativePaths: map[string]string{"3440x1440": "/deriv.jpg"},
+		CropAnchors:     map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter},
+	}
+	store.Add(img)
+
+	// Step 2: Pipeline picks up image (via MergeExistingMetadata — gets TopCenter)
+	// ... pipeline is processing ...
+
+	// Step 3: User changes anchor to BottomRight while pipeline runs
+	store.SetCropAnchor("img1", "3440x1440", provider.AnchorBottomRight)
+
+	// Step 4: Pipeline finishes — its struct has the OLD anchor from MergeExistingMetadata
+	pipelineResult := provider.Image{
+		ID:              "img1",
+		DerivativePaths: map[string]string{"3440x1440": "/new_deriv.jpg"},
+		CropAnchors:     map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter}, // stale!
+	}
+	store.replace(pipelineResult)
+
+	// Step 5: User's BottomRight must win
+	got, _ := store.GetByID("img1")
+	assert.Equal(t, provider.AnchorBottomRight, got.CropAnchors["3440x1440"],
+		"User's latest anchor choice must win over the pipeline's stale copy")
+}
+
+// TestCropAnchor_ZombieExemption verifies that determineSyncAction() returns
+// ImageActionKeep (not ImageActionDelete) for invalidated images that have
+// user-set CropAnchors.
+func TestCropAnchor_ZombieExemption(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, fm := newZombieTestStore(t, tmpDir)
+	flags := defaultTargetFlags()
+
+	// Create an image with correct flags, master file, but NO derivatives
+	// (this is the state after Sync #1 invalidation)
+	img := newZombieImage(t, fm, "anchored_zombie", "q1", flags)
+	img.CropAnchors = map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter}
+	store.Add(img)
+
+	// Also add a true zombie (no anchors) to verify it's still deleted
+	trueZombie := newZombieImage(t, fm, "true_zombie", "q1", flags)
+	store.Add(trueZombie)
+
+	// Sync — should keep the anchored image, delete the true zombie
+	store.Sync(100, flags, nil)
+
+	known := store.GetKnownIDs()
+	assert.True(t, known["anchored_zombie"],
+		"Image with CropAnchors must survive zombie detection")
+	assert.False(t, known["true_zombie"],
+		"True zombie (no CropAnchors) must still be deleted")
+
+	// Verify anchors are intact
+	got, _ := store.GetByID("anchored_zombie")
+	assert.Equal(t, provider.AnchorTopCenter, got.CropAnchors["3440x1440"])
+}
+
+// TestCropAnchor_ZombieWithoutAnchors_StillDeleted verifies that the zombie
+// recovery path still functions correctly for images without CropAnchors.
+// This is a guard against accidental over-protection.
+func TestCropAnchor_ZombieWithoutAnchors_StillDeleted(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, fm := newZombieTestStore(t, tmpDir)
+	flags := defaultTargetFlags()
+
+	// Three zombies: nil anchors, empty map, and zero-length map
+	zombie1 := newZombieImage(t, fm, "z_nil", "q1", flags)
+	zombie1.CropAnchors = nil
+	store.Add(zombie1)
+
+	zombie2 := newZombieImage(t, fm, "z_empty", "q1", flags)
+	zombie2.CropAnchors = map[string]provider.CropAnchor{}
+	store.Add(zombie2)
+
+	zombie3 := newZombieImage(t, fm, "z_default", "q1", flags)
+	// CropAnchors not set (zero value)
+	store.Add(zombie3)
+
+	// A healthy image to keep the store non-empty
+	healthy := newHealthyImage(t, fm, "healthy", "q1", "3440x1440", flags)
+	store.Add(healthy)
+
+	store.Sync(100, flags, nil)
+
+	assert.Equal(t, 1, store.Count(), "Only healthy image should remain")
+	assert.True(t, store.GetKnownIDs()["healthy"])
+	assert.False(t, store.GetKnownIDs()["z_nil"], "Zombie with nil CropAnchors must be deleted")
+	assert.False(t, store.GetKnownIDs()["z_empty"], "Zombie with empty CropAnchors must be deleted")
+	assert.False(t, store.GetKnownIDs()["z_default"], "Zombie with default CropAnchors must be deleted")
+}
+
+// =============================================================================
+// Category 2: Lifecycle Scenarios (Integration-Level)
+// =============================================================================
+
+// TestCropAnchor_SurviveDoubleSyncModeChange reproduces the EXACT production
+// bug: user sets a crop anchor, then changes SmartFit mode. The double-Sync
+// pattern (invalidation → zombie check) must NOT destroy the anchor.
+//
+// Kill chain without fix:
+//
+//	Sync #1: flag mismatch → ImageActionInvalidate → DerivativePaths wiped
+//	Sync #2: flags match, DerivativePaths=0 → ImageActionDelete → CropAnchors GONE
+//
+// With fix:
+//
+//	Sync #2: flags match, DerivativePaths=0, CropAnchors>0 → ImageActionKeep
+func TestCropAnchor_SurviveDoubleSyncModeChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, cacheFile)
+
+	// === SETUP: Image processed with SmartFit Aggressive mode ===
+	originalFlags := makeDownloaderFlags(true, SmartFitAggressive, false, false)
+	img := provider.Image{
+		ID:              "victim_img",
+		SourceQueryID:   "q1",
+		ProcessingFlags: copyFlags(originalFlags),
+		DerivativePaths: map[string]string{"3440x1440": filepath.Join(tmpDir, "fitted", "victim.jpg")},
+	}
+	createMasterFile(t, fm, "victim_img")
+	store.Add(img)
+
+	// User sets a crop anchor
+	store.SetCropAnchor("victim_img", "3440x1440", provider.AnchorBottomCenter)
+
+	// Verify setup
+	got, _ := store.GetByID("victim_img")
+	assert.Equal(t, provider.AnchorBottomCenter, got.CropAnchors["3440x1440"],
+		"Setup: anchor should be set")
+	assert.NotEmpty(t, got.DerivativePaths, "Setup: derivatives should exist")
+
+	// === SYNC #1: User changes SmartFit to Normal mode ===
+	// This is the mode change that triggers invalidation
+	newTarget := makeGroomingTarget(true, SmartFitNormal, false, false)
+	store.Sync(100, newTarget, nil)
+
+	// After Sync #1: image should be invalidated (derivatives wiped) but alive
+	got, ok := store.GetByID("victim_img")
+	assert.True(t, ok, "Image must survive invalidation")
+	assert.Empty(t, got.DerivativePaths, "Derivatives should be wiped by invalidation")
+	assert.Equal(t, provider.AnchorBottomCenter, got.CropAnchors["3440x1440"],
+		"CropAnchors must survive invalidation")
+
+	// === SYNC #2: The killer — same flags, zero derivatives ===
+	// Without the fix, this zombie-deletes the image and CropAnchors are gone forever.
+	store.Sync(100, newTarget, nil)
+
+	// === ASSERTION: Image and anchors MUST survive ===
+	got, ok = store.GetByID("victim_img")
+	assert.True(t, ok,
+		"CRITICAL: Image must survive the double-Sync pattern — zombie exemption must fire")
+	assert.Equal(t, provider.AnchorBottomCenter, got.CropAnchors["3440x1440"],
+		"CRITICAL: CropAnchors must survive the double-Sync pattern")
+}
+
+// TestCropAnchor_SurviveTripleSyncStartup verifies that anchors survive 3
+// consecutive Sync calls, which can happen during worst-case startup:
+// Activate() + RefreshImagesAndPulse() + scheduler.
+func TestCropAnchor_SurviveTripleSyncStartup(t *testing.T) {
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	flags := makeDownloaderFlags(true, SmartFitAggressive, false, false)
+	target := makeGroomingTarget(true, SmartFitAggressive, false, false)
+
+	// Image with matching flags and anchor
+	img := newHealthyImage(t, fm, "triple_sync", "q1", "3440x1440", flags)
+	img.CropAnchors = map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopLeft}
+	store.Add(img)
+
+	// Three consecutive syncs with identical flags (steady-state startup)
+	store.Sync(100, target, nil)
+	store.Sync(100, target, nil)
+	store.Sync(100, target, nil)
+
+	got, ok := store.GetByID("triple_sync")
+	assert.True(t, ok, "Image must survive three consecutive Syncs")
+	assert.Equal(t, provider.AnchorTopLeft, got.CropAnchors["3440x1440"],
+		"CropAnchors must survive three consecutive Syncs")
+	assert.NotEmpty(t, got.DerivativePaths, "Derivatives should be preserved (flags matched)")
+}
+
+// TestCropAnchor_SurviveSaveLoadCycle verifies that CropAnchors persist
+// across cache serialization/deserialization (JSON round-trip).
+func TestCropAnchor_SurviveSaveLoadCycle(t *testing.T) {
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	cacheFile := filepath.Join(tmpDir, "cache.json")
+
+	// Session 1: Create image, set anchor, save
+	store1 := NewImageStore()
+	store1.SetAsyncSave(false)
+	store1.SetFileManager(fm, cacheFile)
+
+	store1.Add(provider.Image{
+		ID:              "persist_test",
+		DerivativePaths: map[string]string{"3440x1440": "/deriv.jpg"},
+	})
+	store1.SetCropAnchor("persist_test", "3440x1440", provider.AnchorMiddleRight)
+	store1.SetCropAnchor("persist_test", "1920x1080", provider.AnchorBottomLeft)
+	store1.SaveCache()
+
+	// Verify cache file was written
+	_, err := os.Stat(cacheFile)
+	assert.NoError(t, err, "Cache file should exist")
+
+	// Session 2: New store, load from disk
+	store2 := NewImageStore()
+	store2.SetAsyncSave(false)
+	store2.SetFileManager(fm, cacheFile)
+	err = store2.LoadCache()
+	assert.NoError(t, err)
+
+	// Verify anchors survived the round-trip
+	got, ok := store2.GetByID("persist_test")
+	assert.True(t, ok)
+	assert.Equal(t, provider.AnchorMiddleRight, got.CropAnchors["3440x1440"],
+		"3440x1440 anchor must survive Save/Load cycle")
+	assert.Equal(t, provider.AnchorBottomLeft, got.CropAnchors["1920x1080"],
+		"1920x1080 anchor must survive Save/Load cycle")
+}
+
+// TestCropAnchor_NotExemptFromQueryPruning verifies that CropAnchors do NOT
+// grant immunity from query-based pruning. If the image's source query is
+// inactive, it should still be deleted — anchors are not a reason to keep
+// orphaned images.
+func TestCropAnchor_NotExemptFromQueryPruning(t *testing.T) {
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	flags := makeDownloaderFlags(true, SmartFitAggressive, false, false)
+
+	// Image from query "qDEAD" with a crop anchor
+	img := newHealthyImage(t, fm, "orphan_anchored", "qDEAD", "3440x1440", flags)
+	img.CropAnchors = map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter}
+	store.Add(img)
+
+	// Image from active query (for comparison)
+	active := newHealthyImage(t, fm, "active_img", "qLIVE", "3440x1440", flags)
+	store.Add(active)
+
+	// Sync with strict query filtering — qDEAD is not in active set
+	activeQueries := map[string]bool{"qLIVE": true}
+	target := makeGroomingTarget(true, SmartFitAggressive, false, false)
+	store.Sync(100, target, activeQueries)
+
+	known := store.GetKnownIDs()
+	assert.False(t, known["orphan_anchored"],
+		"CropAnchors must NOT protect images from inactive-query pruning")
+	assert.True(t, known["active_img"],
+		"Active query image should survive")
+}
+
+// TestCropAnchor_NotExemptFromLRUPruning verifies that CropAnchors do NOT
+// grant immunity from cache-limit (LRU) pruning. If the store exceeds its
+// limit, older images with anchors are still evicted.
+func TestCropAnchor_NotExemptFromLRUPruning(t *testing.T) {
+	tmpDir := t.TempDir()
+	fm := NewFileManager(tmpDir)
+	store := NewImageStore()
+	store.SetAsyncSave(false)
+	store.SetFileManager(fm, filepath.Join(tmpDir, "cache.json"))
+
+	flags := makeDownloaderFlags(true, SmartFitAggressive, false, false)
+
+	// Add 5 images, all with crop anchors
+	for i := 0; i < 5; i++ {
+		id := "lru_" + string(rune('A'+i))
+		img := newHealthyImage(t, fm, id, "q1", "3440x1440", flags)
+		img.CropAnchors = map[string]provider.CropAnchor{"3440x1440": provider.AnchorTopCenter}
+		store.Add(img)
+	}
+	assert.Equal(t, 5, store.Count())
+
+	// Sync with limit 2 — oldest 3 should be pruned despite having anchors
+	target := makeGroomingTarget(true, SmartFitAggressive, false, false)
+	store.Sync(2, target, nil)
+
+	assert.Equal(t, 2, store.Count(),
+		"Cache limit must be enforced even for images with CropAnchors")
+}

--- a/pkg/wallpaper/store.go
+++ b/pkg/wallpaper/store.go
@@ -116,6 +116,19 @@ func (s *ImageStore) replace(img provider.Image) bool {
 			if len(img.DerivativePaths) == 0 && len(existing.DerivativePaths) > 0 {
 				log.Debugf("[Store] WARNING: replace() clearing DerivativePaths for %s (had %d paths)", img.ID, len(existing.DerivativePaths))
 			}
+			// Preserve user-set CropAnchors — the store is authoritative for user metadata.
+			// The pipeline never writes CropAnchors, so existing store values always win.
+			// The else branch ensures that if the user removed all anchors (via AnchorAuto)
+			// while the pipeline was in-flight, stale anchors from MergeExistingMetadata
+			// are not resurrected.
+			if len(existing.CropAnchors) > 0 {
+				img.CropAnchors = make(map[string]provider.CropAnchor, len(existing.CropAnchors))
+				for k, v := range existing.CropAnchors {
+					img.CropAnchors[k] = v
+				}
+			} else {
+				img.CropAnchors = nil
+			}
 			// Incremental bucket update: remove old entries, add new ones
 			s.removeFromBucketsLocked(existing.ID, existing.DerivativePaths)
 			s.images[i] = img
@@ -817,6 +830,13 @@ func (s *ImageStore) determineSyncAction(img provider.Image, activeQueryIDs map[
 	// permanently invisible to monitors. Delete it so the fetcher can
 	// re-download and reprocess it on the next cycle.
 	if len(img.DerivativePaths) == 0 {
+		// Preserve images with user-set CropAnchors: they are legitimately invalidated
+		// (not true zombies) and will be reprocessed via backlog healing on the next
+		// fetch cycle, where MergeExistingMetadata will copy the anchors forward.
+		if len(img.CropAnchors) > 0 {
+			log.Debugf("[Sync] Keeping invalidated image %s (has %d crop anchors)", img.ID, len(img.CropAnchors))
+			return ImageActionKeep
+		}
 		log.Debugf("[Sync] Recovery: deleting zombie image %s (master exists, flags match, but no derivatives)", img.ID)
 		return ImageActionDelete
 	}


### PR DESCRIPTION
## Description

User-set crop anchors were **deterministically destroyed** whenever processing settings changed (Smart Fit mode, Face Crop, etc.). This was not a race condition — it was a guaranteed data loss on every settings change, app restart with changed settings, or nightly grooming cycle.

### Root Cause: Two Independent Bugs

**Bug 1 — Double-Sync Zombie Deletion (`determineSyncAction`)**

When processing settings changed, `syncStoreWithConfig()` triggered `Sync()` twice in quick succession:

1. **Sync #1**: Detected a flag mismatch → `ImageActionInvalidate` → wiped `DerivativePaths` to `{}`, but left `CropAnchors` intact.
2. **Sync #2**: Flags now matched, but `DerivativePaths` was empty → the zombie recovery heuristic classified the image as corrupted → `ImageActionDelete` → **image deleted from store, CropAnchors gone forever**.

On the next fetch cycle, the provider returned the same image as a fresh struct with `CropAnchors: nil`. Since the image was deleted, `GetByID` failed, `MergeExistingMetadata` never ran, and the anchor was permanently lost.

**Fix**: Images with `len(CropAnchors) > 0` are now exempted from zombie deletion — they return `ImageActionKeep` instead. They survive in the store so the backlog healing path can merge anchors via `MergeExistingMetadata` on the next fetch.

**Bug 2 — Pipeline `replace()` Clobber**

`replace()` performed a full struct overwrite (`s.images[i] = img`). If the user set a crop anchor while the pipeline was processing, the pipeline's completion would overwrite the store entry with its stale struct — destroying the user's newer anchor.

**Fix**: `replace()` now deep-copies the store's existing `CropAnchors` into the incoming pipeline struct before the overwrite. The store is the single source of truth for user-set metadata; the pipeline never writes `CropAnchors`. An `else` branch sets `CropAnchors = nil` when the store has none, preventing stale values from `MergeExistingMetadata` from resurrecting anchors the user explicitly removed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

**10 new regression tests** in `crop_anchor_regression_test.go`, organized into two categories:

### Fix Mechanics (Unit-Level)
| Test | Verifies |
|---|---|
| `TestCropAnchor_Replace_PreservesExisting` | `replace()` with pipeline struct (no anchors) preserves store anchors |
| `TestCropAnchor_Replace_HonorsRemoval` | User-removed anchors are NOT resurrected by stale pipeline data |
| `TestCropAnchor_Replace_MidFlight` | User's latest anchor wins over pipeline's stale copy |
| `TestCropAnchor_ZombieExemption` | Invalidated image with anchors → `ImageActionKeep` |
| `TestCropAnchor_ZombieWithoutAnchors_StillDeleted` | True zombies (no anchors) still cleaned up |

### Lifecycle Scenarios (Integration-Level)
| Test | Verifies |
|---|---|
| `TestCropAnchor_SurviveDoubleSyncModeChange` | **Exact production bug repro** — the double-Sync kill chain |
| `TestCropAnchor_SurviveTripleSyncStartup` | Anchors survive 3 consecutive Syncs (worst-case startup) |
| `TestCropAnchor_SurviveSaveLoadCycle` | JSON round-trip persistence |
| `TestCropAnchor_NotExemptFromQueryPruning` | Anchors don't grant immunity from inactive-query cleanup |
| `TestCropAnchor_NotExemptFromLRUPruning` | Anchors don't bypass cache-limit eviction |

### Results
- ✅ All 10 new tests pass
- ✅ Full existing test suite passes (0 regressions)
- ✅ Race detector clean (`go test -race`)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
```