### PR TITLE
fix(wallpaper): guard against nil jobSubmitter to prevent crash

### DIFF
--- a/pkg/wallpaper/fetch_logic.go
+++ b/pkg/wallpaper/fetch_logic.go
@@ -38,8 +38,9 @@ func (wp *Plugin) FetchNewImages(force bool, providerID ...string) {
 			}())
 
 			wp.downloadMutex.RLock()
-			if wp.cfg == nil {
+			if wp.cfg == nil || wp.jobSubmitter == nil {
 				wp.downloadMutex.RUnlock()
+				log.Println("Fetch skipped - plugin not fully activated yet (pipeline not ready).")
 				return
 			}
 			wp.cfg.mu.Lock()
@@ -220,6 +221,17 @@ func (wp *Plugin) fetchFromProvider(fetchCtx context.Context, q ImageQuery, p pr
 
 	queuedForThisQuery := 0
 
+	// Defense in depth: the pipeline may not be ready yet (pre-Activate window) or may
+	// have been torn down by a concurrent Deactivate. Bail out without advancing pagination
+	// instead of dereferencing a nil jobSubmitter interface.
+	wp.downloadMutex.RLock()
+	submitter := wp.jobSubmitter
+	wp.downloadMutex.RUnlock()
+	if submitter == nil {
+		log.Printf("Fetch aborted for query %s: pipeline not available (plugin activating or deactivating).", q.ID)
+		return
+	}
+
 	// Instantiate the background cancellation context for this specific query
 	queryCtx := wp.GetOrCreateQueryContext(q.ID)
 
@@ -260,7 +272,7 @@ func (wp *Plugin) fetchFromProvider(fetchCtx context.Context, q ImageQuery, p pr
 			Provider: p,
 		}
 		// Submit blocking (until buffer clears or fetchCtx aborts)
-		if wp.jobSubmitter.Submit(fetchCtx, job) {
+		if submitter.Submit(fetchCtx, job) {
 			totalQueued.Increment()
 			queuedForThisQuery++
 		} else {

--- a/pkg/wallpaper/wallpaper.go
+++ b/pkg/wallpaper/wallpaper.go
@@ -369,8 +369,13 @@ func (wp *Plugin) Activate() {
 	}
 	// Create a new context for this activation cycle
 	wp.ctx, wp.cancel = context.WithCancel(context.Background())
-	wp.pipeline = NewPipeline(wp.ctx, wp.cfg, wp.store.(*ImageStore), wp.ProcessImageJob, wp.getAPILimiter, wp.getProcessLimiter)
-	wp.jobSubmitter = wp.pipeline
+	pipeline := NewPipeline(wp.ctx, wp.cfg, wp.store.(*ImageStore), wp.ProcessImageJob, wp.getAPILimiter, wp.getProcessLimiter)
+	// Publish the pipeline/submitter under the same lock used by the fetch goroutines that
+	// read wp.jobSubmitter, so the pre-Activate nil guard is race-free.
+	wp.downloadMutex.Lock()
+	wp.pipeline = pipeline
+	wp.jobSubmitter = pipeline
+	wp.downloadMutex.Unlock()
 
 	if err := wp.fm.EnsureDirs(); err != nil {
 		log.Printf("Warning: Error ensuring directories: %v. Some features may be limited.", err)
@@ -510,9 +515,15 @@ func (wp *Plugin) Deactivate() {
 
 	wp.stopAllWorkers()
 
-	// Stop Pipeline
-	if wp.pipeline != nil {
-		wp.pipeline.Stop()
+	// Stop Pipeline and clear the submitter so any fetch goroutine racing past the
+	// context cancellation bails out via the nil guard instead of using a stopped pipeline.
+	wp.downloadMutex.Lock()
+	pipeline := wp.pipeline
+	wp.jobSubmitter = nil
+	wp.pipeline = nil
+	wp.downloadMutex.Unlock()
+	if pipeline != nil {
+		pipeline.Stop()
 	}
 	// Note: CancelFetchContext() already called at top of Deactivate().
 


### PR DESCRIPTION
## Problem

Fetch goroutines could dereference a nil `jobSubmitter` and panic when running in the pre-`Activate` window, or while a concurrent `Deactivate` tore down the pipeline.

## Fix

- **`FetchNewImages`**: skip when `jobSubmitter` is nil (plugin not fully activated yet).
- **`fetchFromProvider`**: snapshot the submitter under `downloadMutex` and bail out without advancing pagination if it is nil (defense in depth against the pre-Activate / Deactivate race).
- **`Activate`**: publish `pipeline`/`jobSubmitter` under `downloadMutex` so the nil guard in the fetch goroutines is race-free.
- **`Deactivate`**: clear `jobSubmitter`/`pipeline` under the lock before stopping, so a racing fetch bails via the nil guard instead of using a stopped pipeline.

## Impact

Prevents a crash during plugin activation/deactivation cycles without changing normal fetch behavior.